### PR TITLE
refactor: simplify playground layout

### DIFF
--- a/apps/web/src/app/playground/layout.tsx
+++ b/apps/web/src/app/playground/layout.tsx
@@ -2,6 +2,6 @@ export const revalidate = false;
 export const dynamic = 'force-dynamic';
 export const fetchCache = 'force-no-store';
 
-export default function PlaygroundLayout({ children }: { children: React.ReactNode }) {
-  return children as any;
+export default function PlaygroundLayout({ children }: { children: React.ReactNode }): React.ReactNode {
+  return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- replace unsafe children cast with React fragment
- specify playground layout return type

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: unknown option '--no-error-on-unmatched-pattern')*

------
https://chatgpt.com/codex/tasks/task_e_689e437a3650832497124e63180f64aa