### PR TITLE
chore: remove hydration warning suppression from root layout

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,7 +8,7 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="ru" suppressHydrationWarning>
+    <html lang="ru">
       <body>
         {children}
       </body>


### PR DESCRIPTION
## Summary
- remove `suppressHydrationWarning` from root layout `<html>` tag

## Testing
- `npm run lint` *(fails: error: unknown option '--no-error-on-unmatched-pattern')*
- `npm run build` *(fails: Type error in src/app/playground/page.tsx:38:5)*
- `TSC_COMPILE_ON_ERROR=true npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689e4e9cda9483248380c195e5f1ca52