### PR TITLE
Fix Playground client-only build and Docker workflow

### DIFF
--- a/.github/workflows/docker-api.yml
+++ b/.github/workflows/docker-api.yml
@@ -33,16 +33,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-- name: Build & Push (GHCR)
-  uses: docker/build-push-action@v6
-  with:
-    context: .
-    file: Dockerfile.api
-    push: true
-    no-cache: true              # вкл. на один прогон, чтобы точно пробить кэш
-    tags: |
-      ghcr.io/grayhex/afterlight-api:latest
-      ghcr.io/grayhex/afterlight-api:main
-      ghcr.io/grayhex/afterlight-api:${{ github.sha }}
-    cache-from: type=gha
-    cache-to: type=gha,mode=max
+      - name: Build & Push (GHCR)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.api
+          push: true
+          no-cache: true              # вкл. на один прогон, чтобы точно пробить кэш
+          tags: |
+            ghcr.io/grayhex/afterlight-api:latest
+            ghcr.io/grayhex/afterlight-api:main
+            ghcr.io/grayhex/afterlight-api:${{ github.sha }}
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/apps/web/src/app/playground/page.tsx
+++ b/apps/web/src/app/playground/page.tsx
@@ -35,7 +35,7 @@ export default function Playground() {
   }
 
   return (
-    <ClientOnly>
+    <ClientOnly fallback={<main className="container">Loading…</main>}>
       <main className="container">
       <h1>Playground (MVP)</h1>
 
@@ -107,6 +107,6 @@ export default function Playground() {
 
       <p className="small">Playground — упрощённый интерфейс для ручного теста API. Авторизации нет; используется заголовок <code>x-user-id</code>.</p>
       </main>
-    </ClientOnly> || <main className="container">Loading…</main>
+    </ClientOnly>
   );
 }

--- a/apps/web/src/components/ClientOnly.tsx
+++ b/apps/web/src/components/ClientOnly.tsx
@@ -6,9 +6,9 @@ import React, { useEffect, useState } from 'react';
  * Рендерит детей только после монтирования на клиенте.
  * Помогает избежать ошибок гидрации (React #418/#423) и расхождений SSR/CSR.
  */
-export default function ClientOnly({ children }: { children: React.ReactNode }) {
+export default function ClientOnly({ children, fallback = null }: { children: React.ReactNode; fallback?: React.ReactNode }) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
-  if (!mounted) return null;
+  if (!mounted) return <>{fallback}</>;
   return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- handle client-only rendering with fallback to fix Playground build
- add provenance flag and proper step placement to Docker API workflow

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: unknown option `--no-error-on-unmatched-pattern`)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e50d8eaf88324ad2a981059388606