### PR TITLE
Fix CD workflow image push

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -44,7 +44,7 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_API }}:${{ github.sha }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_API }},push-by-digest=true
+          provenance: false
 
       # WEB image
       - name: Build & push WEB
@@ -52,11 +52,11 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./Dockerfile.next
+          file: ./Dockerfile.web
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_WEB }}:${{ github.sha }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_WEB }},push-by-digest=true
+          provenance: false
 
   deploy:
     name: deploy-to-k3s


### PR DESCRIPTION
## Summary
- fix cd workflow push stage by removing push-by-digest and disabling provenance
- use Dockerfile.web for web image in cd workflow

## Testing
- `./.bin/actionlint`

------
https://chatgpt.com/codex/tasks/task_e_689e54e16b70832495a9fc6d30215437