### PR TITLE
Fix deploy workflow to run on self-hosted k3s runner

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -60,7 +60,7 @@ jobs:
 
   deploy:
     name: deploy-to-k3s
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: build
     steps:
       - name: Write kubeconfig from secret


### PR DESCRIPTION
## Summary
- ensure CD job uses self-hosted runner for k3s deployment

## Testing
- `cd apps/api && npm test`
- `cd apps/web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e5d48bd0883249b2a6cd5784b7f1f