### PR TITLE
fix: use afterlight-staging namespace

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -62,6 +62,8 @@ jobs:
     name: deploy-to-k3s
     runs-on: self-hosted
     needs: build
+    env:
+      NS: afterlight-staging
     steps:
       - name: Write kubeconfig from secret
         run: |
@@ -73,7 +75,6 @@ jobs:
         env:
           API_DIGEST: ${{ needs.build.outputs.api_digest }}
           WEB_DIGEST: ${{ needs.build.outputs.web_digest }}
-          NS: afterlight
         run: |
           # Узкие места: имена контейнеров в деплойментах!
           kubectl -n $NS set image deploy/afterlight-api api=${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_API }}@${API_DIGEST}
@@ -81,5 +82,5 @@ jobs:
 
       - name: Wait for rollout
         run: |
-          kubectl -n afterlight rollout status deploy/afterlight-api
-          kubectl -n afterlight rollout status deploy/afterlight-web
+          kubectl -n $NS rollout status deploy/afterlight-api
+          kubectl -n $NS rollout status deploy/afterlight-web

--- a/k8s/base/web-deployment.yaml
+++ b/k8s/base/web-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: afterlight-web
-  namespace: afterlight
+  namespace: afterlight-staging
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
## Summary
- deploy to afterlight-staging namespace
- ensure kubectl commands use the same namespace
- set web deployment manifest to afterlight-staging

## Testing
- `npm test` (apps/api) *(fails: Missing script "test")*
- `npm test` (apps/web) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e618839d88324acaae7ed05851697