### PR TITLE
chore: verify kubectl before deployment

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -69,6 +69,11 @@ jobs:
           echo "${{ secrets.KUBECONFIG_AFTERLIGHT }}" > $HOME/.kube/config
           chmod 600 $HOME/.kube/config
 
+      - name: Check kubectl and kubeconfig
+        run: |
+          kubectl version --client
+          kubectl config current-context
+
       - name: Set images on deployments
         env:
           API_DIGEST: ${{ needs.build.outputs.api_digest }}


### PR DESCRIPTION
## Summary
- check kubectl version and current context before setting images in CD workflow

## Testing
- `npm run build` (apps/api)
- `npm run build` (apps/web)


------
https://chatgpt.com/codex/tasks/task_e_689e6192917c8324932e35ae7958bc99