### PR TITLE
ci: specify linux label for self-hosted deploy runner

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -60,7 +60,7 @@ jobs:
 
   deploy:
     name: deploy-to-k3s
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux]  # или добавить собственные метки раннера
     needs: build
     steps:
       - name: Write kubeconfig from secret


### PR DESCRIPTION
## Summary
- ensure deploy job targets self-hosted runner with linux label

## Testing
- `./config.sh --labels self-hosted,linux` *(fails: No such file or directory)*
- `(cd apps/api && npm test)` *(fails: Missing script "test")*
- `(cd apps/web && npm test)` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e619a859883248a3705c8824003be