### PR TITLE
Fix k3s deploy job kubeconfig usage

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -70,6 +70,7 @@ jobs:
           mkdir -p $HOME/.kube
           echo "${{ secrets.KUBECONFIG_AFTERLIGHT }}" > $HOME/.kube/config
           chmod 600 $HOME/.kube/config
+          echo "KUBECONFIG=$HOME/.kube/config" >> $GITHUB_ENV
 
       - name: Check kubectl and kubeconfig
         run: |


### PR DESCRIPTION
## Summary
- export kubeconfig path in deploy workflow so k3s `kubectl` uses the provided secret instead of the root-only system config

## Testing
- `cd apps/api && npm test` *(fails: Missing script "test")*
- `cd apps/web && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ed7c94cb083248c54a17f0ec54f70