### PR TITLE
feat: run standalone web via node

### DIFF
--- a/k8s/base/web-deployment.yaml
+++ b/k8s/base/web-deployment.yaml
@@ -17,6 +17,7 @@ spec:
         - name: web
           image: ghcr.io/grayhex/afterlight-web:latest
           imagePullPolicy: Always
+          command: ["node", "server.js"]
           envFrom:
             - configMapRef:
                 name: afterlight-web-config

--- a/k8s/deploy-web-ssr.yaml
+++ b/k8s/deploy-web-ssr.yaml
@@ -23,6 +23,7 @@ spec:
       - name: web
         image: ghcr.io/grayhex/afterlight-web:latest
         imagePullPolicy: Always
+        command: ["node", "server.js"]
         env:
         - name: PORT
           value: "3000"


### PR DESCRIPTION
## Summary
- run standalone web container using `node server.js`
- adjust Kubernetes deployment manifests for standalone runtime

## Testing
- `kubectl apply --dry-run=client -f k8s/base/web-deployment.yaml` *(fails: kubectl not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689efac88cb883248e8dca33410b9dc4