### PR TITLE
feat(web): add wireframe routes

### DIFF
--- a/apps/web/README-WEB-WIREFRAMES.md
+++ b/apps/web/README-WEB-WIREFRAMES.md
@@ -14,11 +14,9 @@
 
 ## Навигация
 - `/` — приветствие
-- `/wireframes` — хаб
-- `/wireframes/owner` — кабинет владельца
-- `/wireframes/owner/wizard` — мастер создания сейфа
-- `/wireframes/verifier` — кабинет верификатора
-- `/wireframes/recipient` — вид получателя
-- `/wireframes/demo` — демо‑сценарий состояний
+- `/wireframes` — хаб со ссылками
+- `/wireframes/owner` — кабинет владельца (заглушка)
+- `/wireframes/verifier` — кабинет верификатора (заглушка)
+- `/wireframes/recipient` — вид получателя (заглушка)
 
 Tailwind уже подключён; UI — условный, с акцентом на структуру и потоки.

--- a/apps/web/src/app/wireframes/layout.tsx
+++ b/apps/web/src/app/wireframes/layout.tsx
@@ -1,0 +1,7 @@
+export const revalidate = false;
+export const dynamic = 'force-dynamic';
+export const fetchCache = 'force-no-store';
+
+export default function WireframesLayout({ children }: { children: React.ReactNode }): React.ReactNode {
+  return <main className="container">{children}</main>;
+}

--- a/apps/web/src/app/wireframes/owner/page.tsx
+++ b/apps/web/src/app/wireframes/owner/page.tsx
@@ -1,0 +1,8 @@
+export default function OwnerWireframe() {
+  return (
+    <>
+      <h1>Кабинет владельца</h1>
+      <p className="small">Заглушка интерфейса.</p>
+    </>
+  );
+}

--- a/apps/web/src/app/wireframes/page.tsx
+++ b/apps/web/src/app/wireframes/page.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+export default function Wireframes() {
+  return (
+    <>
+      <h1>Wireframes</h1>
+      <ul>
+        <li><Link href="/wireframes/owner">Кабинет владельца</Link></li>
+        <li><Link href="/wireframes/verifier">Кабинет верификатора</Link></li>
+        <li><Link href="/wireframes/recipient">Вид получателя</Link></li>
+      </ul>
+    </>
+  );
+}

--- a/apps/web/src/app/wireframes/recipient/page.tsx
+++ b/apps/web/src/app/wireframes/recipient/page.tsx
@@ -1,0 +1,8 @@
+export default function RecipientWireframe() {
+  return (
+    <>
+      <h1>Вид получателя</h1>
+      <p className="small">Заглушка интерфейса.</p>
+    </>
+  );
+}

--- a/apps/web/src/app/wireframes/verifier/page.tsx
+++ b/apps/web/src/app/wireframes/verifier/page.tsx
@@ -1,0 +1,8 @@
+export default function VerifierWireframe() {
+  return (
+    <>
+      <h1>Кабинет верификатора</h1>
+      <p className="small">Заглушка интерфейса.</p>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add wireframes hub and stubs for owner, verifier, and recipient
- document new wireframe routes

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: unknown option `--no-error-on-unmatched-pattern`)
- `npx next lint` (prompts for interactive config)


------
https://chatgpt.com/codex/tasks/task_e_689f10e335b883249e6875483c88beeb