### PR TITLE
feat(api): validate block recipient assignment

### DIFF
--- a/apps/api/src/blocks/blocks.controller.ts
+++ b/apps/api/src/blocks/blocks.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, Post, Delete, Param, Body, Query } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Post, Delete, Param, Body, Query, ParseUUIDPipe } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags, ApiOperation, ApiParam } from '@nestjs/swagger';
 import { BlocksService } from './blocks.service';
 import { CreateBlockDto } from './dto/create-block.dto';
 import { AssignRecipientDto } from './dto/assign-recipient.dto';
@@ -38,14 +38,21 @@ export class BlocksController {
   }
 
   @Get(':id/recipients')
-  listRecipients(@CurrentUserId() userId: string, @Param('id') id: string) {
+  @ApiOperation({ summary: 'List recipients assigned to a block' })
+  @ApiParam({ name: 'id', format: 'uuid' })
+  listRecipients(
+    @CurrentUserId() userId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
     return this.service.listRecipients(userId, id);
   }
 
   @Post(':id/recipients')
+  @ApiOperation({ summary: 'Assign a recipient to a block' })
+  @ApiParam({ name: 'id', format: 'uuid' })
   assignRecipient(
     @CurrentUserId() userId: string,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: AssignRecipientDto,
   ) {
     return this.service.assignRecipient(userId, id, dto);

--- a/apps/api/src/blocks/dto/assign-recipient.dto.ts
+++ b/apps/api/src/blocks/dto/assign-recipient.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsUUID, MaxLength } from 'class-validator';
+import { IsString, IsUUID, MaxLength, MinLength } from 'class-validator';
 
 export class AssignRecipientDto {
   @ApiProperty({ format: 'uuid' })
@@ -8,6 +8,7 @@ export class AssignRecipientDto {
 
   @ApiProperty({ description: 'DEK wrapped for this recipient (base64 or JWE compact)' })
   @IsString()
+  @MinLength(1)
   @MaxLength(8192)
   dek_wrapped_for_recipient!: string;
 }


### PR DESCRIPTION
## Summary
- enforce non-empty base64/JWE for recipient DEK
- document recipient endpoints and validate block IDs

## Testing
- `cd apps/api && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f161f8ef88324a03688d4c3ce1d00