### PR TITLE
fix: import notifications module in verifiers service

### DIFF
--- a/apps/api/src/verifiers/verifiers.module.ts
+++ b/apps/api/src/verifiers/verifiers.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { VerifiersService } from './verifiers.service';
 import { VerifiersController } from './verifiers.controller';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
+  imports: [NotificationsModule],
   controllers: [VerifiersController],
   providers: [VerifiersService],
   exports: [VerifiersService],


### PR DESCRIPTION
## Summary
- wire VerifiersModule up with NotificationsModule so the API starts

## Testing
- `npm test`
- `npm run build`
- `DATABASE_URL=file:dev.db npm start` *(fails later due to missing DB but module initialization succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_689f0ad9a3088324b00e523ebbe45698