### PR TITLE
feat(web): add layout components

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,9 @@
 import "./globals.css";
 import type { ReactNode } from "react";
+import Link from "next/link";
+import Header from "../components/Header";
+import Navigation from "../components/Navigation";
+import Footer from "../components/Footer";
 
 export const metadata = {
   title: "AfterLight",
@@ -9,8 +13,18 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ru">
-      <body>
-        {children}
+      <body className="flex min-h-screen flex-col">
+        <Header />
+        <Navigation />
+        <main className="container flex-1 py-4">
+          {children}
+          <div className="mt-8">
+            <Link href="/playground" className="text-sky-600 hover:underline">
+              Back to Playground
+            </Link>
+          </div>
+        </main>
+        <Footer />
       </body>
     </html>
   );

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+export default function Footer() {
+  return (
+    <footer className="bg-mist mt-auto">
+      <div className="container p-4 text-center text-sm text-slate-500">
+        © {new Date().getFullYear()} AfterLight
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,0 +1,9 @@
+export default function Header() {
+  return (
+    <header className="bg-ink text-white">
+      <div className="container py-4 text-center md:text-left">
+        <h1 className="text-xl font-semibold">AfterLight</h1>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/components/Navigation.tsx
+++ b/apps/web/src/components/Navigation.tsx
@@ -1,0 +1,11 @@
+import Link from "next/link";
+
+export default function Navigation() {
+  return (
+    <nav className="bg-mist">
+      <div className="container flex flex-wrap gap-4 p-4">
+        <Link href="/" className="hover:underline">Home</Link>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add Header, Navigation and Footer components with basic styling
- wire new components into app layout and link back to Playground

## Testing
- ⚠️ `npm test` (missing script)
- ⚠️ `npm run lint` (unknown option)
- ⚠️ `npx next lint` (interactive prompt, aborted)


------
https://chatgpt.com/codex/tasks/task_e_689f2c1220808324bf5a3fe3d392c7c2