### PR TITLE
Fix landing page build error with framer-motion

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.2",
       "dependencies": {
         "framer-motion": "^12.23.12",
+        "lucide-react": "^0.539.0",
         "next": "14.2.5",
         "react": "18.3.1",
         "react-dom": "18.3.1"
@@ -1047,6 +1048,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.539.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.539.0.tgz",
+      "integrity": "sha512-VVISr+VF2krO91FeuCrm1rSOLACQUYVy7NQkzrOty52Y8TlTPcXcMdQFj9bYzBgXbWCiywlwSZ3Z8u6a+6bMlg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "framer-motion": "^12.23.12",
+    "lucide-react": "^0.539.0",
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import React from "react";
-import { motion } from "framer-motion";
+import { motion } from "@/lib/motion";
 import { Shield, HeartPulse, Users, Share2, FileLock, Link2, Github, Play, KeyRound, Sparkles, Mail, Settings, ShieldCheck, User } from "lucide-react";
 
 /**

--- a/apps/web/src/lib/motion.ts
+++ b/apps/web/src/lib/motion.ts
@@ -1,0 +1,5 @@
+'use client';
+
+import * as m from 'framer-motion/m';
+
+export const motion = m;


### PR DESCRIPTION
## Summary
- wrap framer-motion imports to avoid unsupported `export *` in client modules
- mark landing page as a client component and add lucide-react icons dependency

## Testing
- `npm run build`
- `npm run lint` *(fails: unknown option '--no-error-on-unmatched-pattern')*


------
https://chatgpt.com/codex/tasks/task_e_689f50c112788324a2896fcc5d604bbe