### PR TITLE
Fix framer-motion import for Next.js client build

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import React from "react";
-import { motion } from "framer-motion";
+import { motion } from "@/lib/motion";
 import { Shield, HeartPulse, Users, Share2, FileLock, Link2, Github, Play, KeyRound, Sparkles, Mail, Settings, ShieldCheck, User } from "lucide-react";
 
 /**


### PR DESCRIPTION
## Summary
- use dedicated motion helper to avoid unsupported `export *` usage
- mark landing page as client component

## Testing
- `npm run lint` *(fails: unknown option '--no-error-on-unmatched-pattern')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f58a5964083249edd84cae23f52a6