### PR TITLE
feat(web): add landing page admin

### DIFF
--- a/apps/web/src/app/adm/page.tsx
+++ b/apps/web/src/app/adm/page.tsx
@@ -1,0 +1,91 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const configPath = path.join(process.cwd(), 'src', 'config', 'landing.json');
+
+async function readConfig() {
+  const data = await fs.readFile(configPath, 'utf-8');
+  return JSON.parse(data);
+}
+
+export default async function AdminPage() {
+  const config = await readConfig();
+
+  async function saveConfig(formData: FormData) {
+    'use server';
+
+    const newConfig = {
+      title: String(formData.get('title') || ''),
+      subtitle: String(formData.get('subtitle') || ''),
+      description: String(formData.get('description') || ''),
+      bgColor: String(formData.get('bgColor') || '#000000'),
+      textColor: String(formData.get('textColor') || '#ffffff'),
+      links: [
+        {
+          text: String(formData.get('link1_text') || ''),
+          href: String(formData.get('link1_href') || ''),
+        },
+        {
+          text: String(formData.get('link2_text') || ''),
+          href: String(formData.get('link2_href') || ''),
+        },
+        {
+          text: String(formData.get('link3_text') || ''),
+          href: String(formData.get('link3_href') || ''),
+        },
+      ],
+    };
+
+    await fs.writeFile(configPath, JSON.stringify(newConfig, null, 2), 'utf-8');
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center p-6">
+      <h1 className="mb-4 text-2xl font-bold">Настройки титульной страницы</h1>
+      <form action={saveConfig} className="flex w-full max-w-xl flex-col gap-4">
+        <label className="flex flex-col gap-1">
+          <span>Название проекта</span>
+          <input name="title" defaultValue={config.title} className="rounded p-2 text-black" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>Подстрочник</span>
+          <input name="subtitle" defaultValue={config.subtitle} className="rounded p-2 text-black" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>Описание</span>
+          <input name="description" defaultValue={config.description} className="rounded p-2 text-black" />
+        </label>
+        <div className="flex gap-4">
+          <label className="flex flex-col gap-1">
+            <span>Цвет фона</span>
+            <input type="color" name="bgColor" defaultValue={config.bgColor} />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span>Цвет текста</span>
+            <input type="color" name="textColor" defaultValue={config.textColor} />
+          </label>
+        </div>
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex gap-4">
+            <input
+              name={`link${i}_text`}
+              defaultValue={config.links[i - 1]?.text || ''}
+              placeholder={`Текст ссылки ${i}`}
+              className="flex-1 rounded p-2 text-black"
+            />
+            <input
+              name={`link${i}_href`}
+              defaultValue={config.links[i - 1]?.href || ''}
+              placeholder="URL"
+              className="flex-1 rounded p-2 text-black"
+            />
+          </div>
+        ))}
+        <button type="submit" className="rounded bg-green-600 px-4 py-2 text-white">
+          Сохранить
+        </button>
+      </form>
+    </main>
+  );
+}
+

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,35 +1,30 @@
-import { Github, Code2, Send } from 'lucide-react';
+import { promises as fs } from 'fs';
+import path from 'path';
 
-export default function Home() {
+async function getConfig() {
+  const filePath = path.join(process.cwd(), 'src', 'config', 'landing.json');
+  const data = await fs.readFile(filePath, 'utf-8');
+  return JSON.parse(data);
+}
+
+export default async function Home() {
+  const config = await getConfig();
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-6">
+    <main
+      className="flex min-h-screen flex-col items-center justify-center p-6"
+      style={{ backgroundColor: config.bgColor, color: config.textColor }}
+    >
       <div className="flex flex-col items-center gap-6 text-center">
-        <h1 className="text-5xl font-bold text-[#10a37f]">Afterlight</h1>
-        <p className="text-base text-neutral-300">
-          Идёт разработка с&nbsp;помощью искусственного интеллекта
-        </p>
-        <p className="text-sm text-neutral-500">
-          Скоро здесь появится серьёзный проект.
-        </p>
+        <h1 className="text-5xl font-bold">{config.title}</h1>
+        <p className="text-base">{config.subtitle}</p>
+        <p className="text-sm">{config.description}</p>
         <div className="mt-4 flex gap-6">
-          <a
-            href="https://github.com/retrotink/afterlight"
-            className="flex items-center gap-2 text-[#10a37f] hover:underline"
-          >
-            <Github className="h-5 w-5" />
-            <span>GitHub</span>
-          </a>
-          <a href="/dev" className="flex items-center gap-2 text-[#10a37f] hover:underline">
-            <Code2 className="h-5 w-5" />
-            <span>/dev</span>
-          </a>
-          <a
-            href="https://t.me/retrotink"
-            className="flex items-center gap-2 text-[#10a37f] hover:underline"
-          >
-            <Send className="h-5 w-5" />
-            <span>@retrotink</span>
-          </a>
+          {config.links.map((link: { text: string; href: string }, idx: number) => (
+            <a key={idx} href={link.href} className="hover:underline">
+              {link.text}
+            </a>
+          ))}
         </div>
       </div>
     </main>

--- a/apps/web/src/config/landing.json
+++ b/apps/web/src/config/landing.json
@@ -1,0 +1,12 @@
+{
+  "title": "Afterlight",
+  "subtitle": "Идёт разработка с\u00a0помощью искусственного интеллекта",
+  "description": "Скоро здесь появится серьёзный проект.",
+  "bgColor": "#000000",
+  "textColor": "#10a37f",
+  "links": [
+    { "text": "GitHub", "href": "https://github.com/retrotink/afterlight" },
+    { "text": "/dev", "href": "/dev" },
+    { "text": "@retrotink", "href": "https://t.me/retrotink" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add JSON-config driven landing page
- implement /adm panel to customize landing page content and colors

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: unknown option '--no-error-on-unmatched-pattern')

------
https://chatgpt.com/codex/tasks/task_e_689f84332988832484fb85cd4d01419a