### PR TITLE
fix: persist landing configuration from admin

### DIFF
--- a/apps/web/src/app/adm/page.tsx
+++ b/apps/web/src/app/adm/page.tsx
@@ -1,5 +1,9 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+export const dynamic = 'force-dynamic';
 
 const configPath = path.join(process.cwd(), 'src', 'config', 'landing.json');
 
@@ -37,6 +41,9 @@ export default async function AdminPage() {
     };
 
     await fs.writeFile(configPath, JSON.stringify(newConfig, null, 2), 'utf-8');
+    revalidatePath('/');
+    revalidatePath('/adm');
+    redirect('/adm');
   }
 
   return (

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,8 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 
+export const dynamic = 'force-dynamic';
+
 async function getConfig() {
   const filePath = path.join(process.cwd(), 'src', 'config', 'landing.json');
   const data = await fs.readFile(filePath, 'utf-8');


### PR DESCRIPTION
## Summary
- revalidate landing and admin pages after saving settings
- force dynamic config reading on the landing page

## Testing
- `npm run lint` *(fails: unknown option '--no-error-on-unmatched-pattern')*
- `npx next lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_689f935c0ee88324a19c66530916e891