### PR TITLE
feat: add footer icons and color controls

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -12,7 +12,8 @@
         "lucide-react": "^0.539.0",
         "next": "14.2.5",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "react-icons": "^4.12.0"
       },
       "devDependencies": {
         "@types/node": "^20.14.10",
@@ -1516,6 +1517,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/read-cache": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,8 @@
     "lucide-react": "^0.539.0",
     "next": "14.2.5",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "react-icons": "^4.12.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/apps/web/src/app/adm/page.tsx
+++ b/apps/web/src/app/adm/page.tsx
@@ -23,21 +23,14 @@ export default async function AdminPage() {
       subtitle: String(formData.get('subtitle') || ''),
       description: String(formData.get('description') || ''),
       bgColor: String(formData.get('bgColor') || '#000000'),
-      textColor: String(formData.get('textColor') || '#ffffff'),
-      links: [
-        {
-          text: String(formData.get('link1_text') || ''),
-          href: String(formData.get('link1_href') || ''),
-        },
-        {
-          text: String(formData.get('link2_text') || ''),
-          href: String(formData.get('link2_href') || ''),
-        },
-        {
-          text: String(formData.get('link3_text') || ''),
-          href: String(formData.get('link3_href') || ''),
-        },
-      ],
+      titleColor: String(formData.get('titleColor') || '#ffffff'),
+      subtitleColor: String(formData.get('subtitleColor') || '#ffffff'),
+      descriptionColor: String(formData.get('descriptionColor') || '#ffffff'),
+      links: {
+        telegram: String(formData.get('telegram') || ''),
+        github: String(formData.get('github') || ''),
+        dev: String(formData.get('dev') || ''),
+      },
     };
 
     await fs.writeFile(configPath, JSON.stringify(newConfig, null, 2), 'utf-8');
@@ -52,42 +45,74 @@ export default async function AdminPage() {
       <form action={saveConfig} className="flex w-full max-w-xl flex-col gap-4">
         <label className="flex flex-col gap-1">
           <span>Название проекта</span>
-          <input name="title" defaultValue={config.title} className="rounded p-2 text-black" />
+          <div className="flex gap-2">
+            <input
+              name="title"
+              defaultValue={config.title}
+              className="flex-1 rounded p-2 text-black"
+            />
+            <input type="color" name="titleColor" defaultValue={config.titleColor} />
+          </div>
         </label>
         <label className="flex flex-col gap-1">
           <span>Подстрочник</span>
-          <input name="subtitle" defaultValue={config.subtitle} className="rounded p-2 text-black" />
+          <div className="flex gap-2">
+            <input
+              name="subtitle"
+              defaultValue={config.subtitle}
+              className="flex-1 rounded p-2 text-black"
+            />
+            <input type="color" name="subtitleColor" defaultValue={config.subtitleColor} />
+          </div>
         </label>
         <label className="flex flex-col gap-1">
           <span>Описание</span>
-          <input name="description" defaultValue={config.description} className="rounded p-2 text-black" />
+          <div className="flex gap-2">
+            <input
+              name="description"
+              defaultValue={config.description}
+              className="flex-1 rounded p-2 text-black"
+            />
+            <input
+              type="color"
+              name="descriptionColor"
+              defaultValue={config.descriptionColor}
+            />
+          </div>
         </label>
         <div className="flex gap-4">
           <label className="flex flex-col gap-1">
             <span>Цвет фона</span>
             <input type="color" name="bgColor" defaultValue={config.bgColor} />
           </label>
-          <label className="flex flex-col gap-1">
-            <span>Цвет текста</span>
-            <input type="color" name="textColor" defaultValue={config.textColor} />
-          </label>
         </div>
-        {[1, 2, 3].map((i) => (
-          <div key={i} className="flex gap-4">
-            <input
-              name={`link${i}_text`}
-              defaultValue={config.links[i - 1]?.text || ''}
-              placeholder={`Текст ссылки ${i}`}
-              className="flex-1 rounded p-2 text-black"
-            />
-            <input
-              name={`link${i}_href`}
-              defaultValue={config.links[i - 1]?.href || ''}
-              placeholder="URL"
-              className="flex-1 rounded p-2 text-black"
-            />
-          </div>
-        ))}
+        <label className="flex flex-col gap-1">
+          <span>Ссылка Telegram</span>
+          <input
+            name="telegram"
+            defaultValue={config.links.telegram}
+            placeholder="URL"
+            className="rounded p-2 text-black"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>Ссылка GitHub</span>
+          <input
+            name="github"
+            defaultValue={config.links.github}
+            placeholder="URL"
+            className="rounded p-2 text-black"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>Ссылка dev build</span>
+          <input
+            name="dev"
+            defaultValue={config.links.dev}
+            placeholder="URL"
+            className="rounded p-2 text-black"
+          />
+        </label>
         <button type="submit" className="rounded bg-green-600 px-4 py-2 text-white">
           Сохранить
         </button>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { FaTelegramPlane, FaGithub, FaCode } from 'react-icons/fa';
 
 export const dynamic = 'force-dynamic';
 
@@ -14,20 +15,33 @@ export default async function Home() {
 
   return (
     <main
-      className="flex min-h-screen flex-col items-center justify-center p-6"
-      style={{ backgroundColor: config.bgColor, color: config.textColor }}
+      className="relative flex min-h-screen flex-col items-center justify-center p-6"
+      style={{ backgroundColor: config.bgColor }}
     >
+      <h1
+        className="absolute left-1/2 top-6 -translate-x-1/2 text-5xl font-bold"
+        style={{ color: config.titleColor }}
+      >
+        {config.title}
+      </h1>
       <div className="flex flex-col items-center gap-6 text-center">
-        <h1 className="text-5xl font-bold">{config.title}</h1>
-        <p className="text-base">{config.subtitle}</p>
-        <p className="text-sm">{config.description}</p>
-        <div className="mt-4 flex gap-6">
-          {config.links.map((link: { text: string; href: string }, idx: number) => (
-            <a key={idx} href={link.href} className="hover:underline">
-              {link.text}
-            </a>
-          ))}
-        </div>
+        <p className="text-base" style={{ color: config.subtitleColor }}>
+          {config.subtitle}
+        </p>
+        <p className="text-sm" style={{ color: config.descriptionColor }}>
+          {config.description}
+        </p>
+      </div>
+      <div className="fixed bottom-6 left-1/2 flex -translate-x-1/2 gap-6">
+        <a href={config.links.telegram} aria-label="Telegram">
+          <FaTelegramPlane className="h-6 w-6" />
+        </a>
+        <a href={config.links.github} aria-label="GitHub">
+          <FaGithub className="h-6 w-6" />
+        </a>
+        <a href={config.links.dev} aria-label="Dev build">
+          <FaCode className="h-6 w-6" />
+        </a>
       </div>
     </main>
   );

--- a/apps/web/src/config/landing.json
+++ b/apps/web/src/config/landing.json
@@ -3,10 +3,12 @@
   "subtitle": "Идёт разработка с\u00a0помощью искусственного интеллекта",
   "description": "Скоро здесь появится серьёзный проект.",
   "bgColor": "#000000",
-  "textColor": "#10a37f",
-  "links": [
-    { "text": "GitHub", "href": "https://github.com/retrotink/afterlight" },
-    { "text": "/dev", "href": "/dev" },
-    { "text": "@retrotink", "href": "https://t.me/retrotink" }
-  ]
+  "titleColor": "#10a37f",
+  "subtitleColor": "#ffffff",
+  "descriptionColor": "#ffffff",
+  "links": {
+    "telegram": "https://t.me/retrotink",
+    "github": "https://github.com/retrotink/afterlight",
+    "dev": "/dev"
+  }
 }


### PR DESCRIPTION
## Summary
- add icon links for Telegram, GitHub and dev build on landing page
- allow configuring individual text colors via admin panel

## Testing
- `npm run lint` *(fails: unknown option '--no-error-on-unmatched-pattern')*
- `npx next lint` *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689f98bf7c8c8324837276c5447d701e