### PR TITLE
Implement mk_wrapped generation and add service tests

### DIFF
--- a/apps/api/src/vaults/vaults.service.ts
+++ b/apps/api/src/vaults/vaults.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/co
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateVaultDto } from './dto/create-vault.dto';
 import { UpdateVaultSettingsDto } from './dto/update-vault-settings.dto';
+import { randomBytes } from 'crypto';
 
 @Injectable()
 export class VaultsService {
@@ -34,6 +35,7 @@ export class VaultsService {
       graceHours: 24,
       isDemo: false,
     };
+    const mkWrapped = randomBytes(32).toString('base64');
     return this.prisma.vault.create({
       data: {
         userId,
@@ -43,7 +45,7 @@ export class VaultsService {
         heartbeatTimeoutDays: dto.heartbeat_timeout_days ?? defaults.heartbeatTimeoutDays,
         graceHours: dto.grace_hours ?? defaults.graceHours,
         isDemo: dto.is_demo ?? defaults.isDemo,
-        mkWrapped: 'TODO:mk_wrapped',
+        mkWrapped,
       },
     });
   }

--- a/apps/api/test/notifications.service.spec.ts
+++ b/apps/api/test/notifications.service.spec.ts
@@ -1,0 +1,49 @@
+import { NotificationsService } from '../src/notifications/notifications.service';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+describe('NotificationsService', () => {
+  let prisma: any;
+  let service: NotificationsService;
+
+  beforeEach(() => {
+    prisma = {
+      notification: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+      },
+    } as any;
+    service = new NotificationsService(prisma);
+  });
+
+  it('enqueues email', async () => {
+    await service.enqueueEmail('v1', 'to@example.com', { subject: 'Subj' });
+    expect(prisma.notification.create).toHaveBeenCalledWith({
+      data: {
+        vault: { connect: { id: 'v1' } },
+        toContact: 'to@example.com',
+        channel: 'email',
+        payload: { subject: 'Subj' },
+        state: 'Queued',
+      },
+    });
+  });
+
+  it('flushes queued emails', async () => {
+    prisma.notification.findMany.mockResolvedValue([
+      { id: 'n1', toContact: 'a', payload: {} },
+      { id: 'n2', toContact: 'b', payload: {} },
+    ]);
+    const count = await service.flushEmailQueue();
+    expect(count).toBe(2);
+    expect(prisma.notification.update).toHaveBeenCalledTimes(2);
+  });
+
+  it('sends verifier invitation via email', async () => {
+    const enqueueSpy = jest.spyOn(service, 'enqueueEmail').mockResolvedValue();
+    const flushSpy = jest.spyOn(service, 'flushEmailQueue').mockResolvedValue(1);
+    await service.sendVerifierInvitation('v1', 'to@example.com', 'tok');
+    expect(enqueueSpy).toHaveBeenCalledWith('v1', 'to@example.com', expect.objectContaining({ subject: expect.any(String) }));
+    expect(flushSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/api/test/vaults.service.spec.ts
+++ b/apps/api/test/vaults.service.spec.ts
@@ -1,0 +1,36 @@
+import { VaultsService } from '../src/vaults/vaults.service';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { UnauthorizedException, NotFoundException } from '@nestjs/common';
+
+describe('VaultsService', () => {
+  let prisma: any;
+  let service: VaultsService;
+
+  beforeEach(() => {
+    prisma = {
+      vault: {
+        create: jest.fn(async ({ data }) => ({ id: 'v1', ...data })),
+        findFirst: jest.fn(),
+      },
+    } as any;
+    service = new VaultsService(prisma);
+  });
+
+  it('creates vault with generated mk_wrapped', async () => {
+    const res = await service.createForUser('u1', {} as any);
+    expect(prisma.vault.create).toHaveBeenCalled();
+    const passed = prisma.vault.create.mock.calls[0][0].data;
+    expect(passed.userId).toBe('u1');
+    expect(passed.mkWrapped).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+    expect(res.mkWrapped).toBe(passed.mkWrapped);
+  });
+
+  it('throws Unauthorized when user id missing', async () => {
+    await expect(service.createForUser('', {} as any)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('throws NotFound when vault not found', async () => {
+    prisma.vault.findFirst.mockResolvedValue(null);
+    await expect(service.getForUser('u1', 'v1')).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/apps/api/test/verifiers.service.spec.ts
+++ b/apps/api/test/verifiers.service.spec.ts
@@ -1,0 +1,46 @@
+import { VerifiersService } from '../src/verifiers/verifiers.service';
+import { NotificationsService } from '../src/notifications/notifications.service';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+
+describe('VerifiersService', () => {
+  let prisma: any;
+  let notify: NotificationsService;
+  let service: VerifiersService;
+
+  beforeEach(() => {
+    prisma = {
+      verifier: { upsert: jest.fn() },
+      vaultVerifier: { findUnique: jest.fn(), create: jest.fn() },
+      verifierInvitation: { create: jest.fn() },
+    } as any;
+    notify = { sendVerifierInvitation: jest.fn() } as any;
+    service = new VerifiersService(prisma, notify);
+  });
+
+  it('invites verifier and sends notification', async () => {
+    prisma.verifier.upsert.mockResolvedValue({ id: 'ver1', contact: 'ver@example.com' });
+    prisma.vaultVerifier.findUnique.mockResolvedValue(null);
+    const link = { id: 'l1', vaultId: 'v1', verifierId: 'ver1', roleStatus: 'Invited', isPrimary: false };
+    prisma.vaultVerifier.create.mockResolvedValue(link);
+    prisma.verifierInvitation.create.mockResolvedValue({});
+
+    const dto = { vault_id: 'v1', contact: 'ver@example.com', expires_in_hours: 10 } as any;
+    const res = await service.invite(dto, 'token123');
+
+    expect(res).toEqual({ invitation: link, token: 'token123' });
+    expect(prisma.verifier.upsert).toHaveBeenCalled();
+    expect(notify.sendVerifierInvitation).toHaveBeenCalledWith('v1', 'ver@example.com', 'token123');
+  });
+
+  it('throws when already invited', async () => {
+    prisma.verifier.upsert.mockResolvedValue({ id: 'ver1', contact: 'ver@example.com' });
+    prisma.vaultVerifier.findUnique.mockResolvedValue({ id: 'existing' });
+    await expect(service.invite({ vault_id: 'v1', contact: 'ver@example.com' } as any, 't')).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('throws NotFound when accepting missing invitation', async () => {
+    prisma.vaultVerifier.findUnique.mockResolvedValue(null);
+    await expect(service.acceptInvitation('v1', 'ver1')).rejects.toBeInstanceOf(NotFoundException);
+  });
+});


### PR DESCRIPTION
## Summary
- Generate and persist random `mkWrapped` when creating vaults
- Add unit tests for VaultsService, VerifiersService, NotificationsService
- Ensure all API service tests pass

## Testing
- `cd apps/api && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fac2d0de083248ba02eedb2d17d7c