### PR TITLE
Use npm ci with lockfile in Dockerfile

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -3,10 +3,10 @@ FROM node:20-alpine AS build
 WORKDIR /app
 RUN apk add --no-cache python3 make g++ && corepack enable
 
-# install deps (no lockfile in repo)
-COPY apps/web/package.json ./apps/web/
+# install deps
+COPY apps/web/package.json apps/web/package-lock.json ./apps/web/
 WORKDIR /app/apps/web
-RUN npm install --no-fund --no-audit
+RUN npm ci --no-fund --no-audit
 
 # copy source separately for better layer caching
 COPY apps/web/ .


### PR DESCRIPTION
## Summary
- Copy `package.json` and `package-lock.json` before installing web app dependencies
- Use `npm ci` to install dependencies from the lockfile in the web Dockerfile

## Testing
- `npm ci --no-fund --no-audit` *(apps/web)*
- `docker build -f Dockerfile.web -t afterlight-web:local .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689fb075a81c8324b7f29f0a357f93c7