### PR TITLE
ci: refine cd workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,6 +3,15 @@ name: cd
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE*"
+      - "CODE_OF_CONDUCT*"
+      - "CONTRIBUTING*"
+      - "LICENSE*"
+      - "CHANGELOG*"
 
 permissions:
   contents: read
@@ -13,6 +22,9 @@ env:
   IMAGE_OWNER: grayhex
   IMAGE_API: afterlight-api
   IMAGE_WEB: afterlight-web
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -55,6 +67,7 @@ jobs:
     name: deploy-to-k3s
     runs-on: self-hosted  # или добавить собственные метки раннера
     needs: build
+    if: ${{ !contains(github.event.head_commit.message, '[skip cd]') }}
     env:
       NS: afterlight
     steps:


### PR DESCRIPTION
## Summary
- ignore docs and templates changes for cd workflow
- cancel outdated cd runs and allow skipping deploy with [skip cd]

## Testing
- `npm test` (apps/api)
- `npm test` (apps/web, fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a01740ca588324a1a2797628a014f5