### PR TITLE
feat: build seed for production runtime

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -20,13 +20,10 @@ WORKDIR /app/apps/api
 COPY --from=deps /app/apps/api/node_modules ./node_modules
 
 # исходники API
-COPY apps/api ./ 
+COPY apps/api ./
 
-# Prisma Client под Debian/OpenSSL 3.0
-RUN npx prisma generate --schema=./prisma/schema.prisma
-
-# сборка NestJS (если скрипт другой — поменяй)
-RUN npm run build
+# Prisma Client под Debian/OpenSSL 3.0 + сборка, чтобы seed попал в dist
+RUN npx prisma generate --schema=./prisma/schema.prisma && npm run build
 
 # оставляем только prod-зависимости
 RUN npm prune --omit=dev

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,9 @@
     "seed": "ts-node prisma/seed.ts",
     "test": "jest"
   },
+  "prisma": {
+    "seed": "node dist/prisma/seed.js"
+  },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "test", "prisma/**/*", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "test", "**/*.spec.ts"]
 }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -18,6 +18,6 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "prisma/**/*", "test/**/*", "**/*.spec.ts"]
+  "include": ["src/**/*.ts", "prisma/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test/**/*", "**/*.spec.ts"]
 }

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,5 +69,8 @@ app.enableCors({
 7) (опц.) PUT /blocks/{id}/public
 
 ## 7. Обновление/роллбэк
-- Обновить: push в main → новый `:latest` → `kubectl -n afterlight rollout restart deploy/afterlight-web`  
+- Обновить: push в main → новый `:latest` → `kubectl -n afterlight rollout restart deploy/afterlight-web`
 - Роллбэк: `kubectl -n afterlight rollout undo deploy/afterlight-web`
+
+## 8. Как запускать сид
+Сид запускается вручную через workflow `seed` с подтверждением `prod`.


### PR DESCRIPTION
## Summary
- configure Prisma seed to run from compiled dist
- compile `prisma/seed.ts` during build
- document manual seed workflow

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a03a500ccc83249e78b90decbd27d6