### PR TITLE
feat(k8s): always pull api image

### DIFF
--- a/k8s/base/api-deployment.yaml
+++ b/k8s/base/api-deployment.yaml
@@ -14,7 +14,7 @@ spec:
       containers:
         - name: api
           image: ghcr.io/grayhex/afterlight-api:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           envFrom:
             - configMapRef: { name: api-config }
             - secretRef: { name: api-secrets }


### PR DESCRIPTION
## Summary
- set imagePullPolicy to Always for API deployment

## Testing
- `kubectl version --client`
- `kubectl apply -f k8s/base/api-deployment.yaml` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a042245d24832497935a80ba7a6f8d