### PR TITLE
feat(api): enable prisma shutdown hooks

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { PrismaService } from './prisma/prisma.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -20,6 +21,9 @@ async function bootstrap() {
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);
+
+  const prismaService = app.get(PrismaService);
+  await prismaService.enableShutdownHooks(app);
 
   await app.listen(process.env.PORT || 3000);
 }


### PR DESCRIPTION
## Summary
- ensure PrismaService gracefully shuts down Nest app

## Testing
- `npm test`
- `npm run build`
- `docker build -f Dockerfile.api .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a049f9e1b88324879100349ec3d8f4