### PR TITLE
fix: include API build artifacts in Docker image

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # минимальный рантайм
+COPY --from=build /app/apps/api/package*.json ./
 COPY --from=build /app/apps/api/node_modules ./node_modules
 COPY --from=build /app/apps/api/dist ./dist
 COPY --from=build /app/apps/api/prisma ./prisma
@@ -50,4 +51,4 @@ ENV HOST=0.0.0.0
 EXPOSE 3000
 
 ENTRYPOINT ["/usr/bin/tini","--"]
-CMD ["node","dist/main.js"]
+CMD ["node","dist/src/main.js"]


### PR DESCRIPTION
## Summary
- ensure API Docker runtime layer contains built dist and Prisma client
- run server from compiled dist/src/main.js

## Testing
- `npm test`
- `docker build -f Dockerfile.api .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a06bd172e48324a8ada14f020bc5d1