### PR TITLE
fix: admin auth in edge runtime

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -7,7 +7,7 @@ export function middleware(req: NextRequest) {
   if (basicAuth) {
     const [scheme, encoded] = basicAuth.split(' ');
     if (scheme === 'Basic') {
-      const decoded = Buffer.from(encoded, 'base64').toString();
+      const decoded = atob(encoded);
       const [user, password] = decoded.split(':');
       if (user === 'admin' && password === expected) {
         return NextResponse.next();


### PR DESCRIPTION
## Summary
- replace Node Buffer with browser-safe base64 decoding for admin auth middleware

## Testing
- `npm run lint` *(fails: unknown option '--no-error-on-unmatched-pattern')*
- `npx next lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a63bbc39708324b03ba61f774abea8