### PR TITLE
feat(web): secure admin routes with Prisma-backed auth

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@afterlight/web",
       "version": "0.0.2",
       "dependencies": {
+        "@prisma/client": "^5.17.0",
         "framer-motion": "^12.23.12",
         "lucide-react": "^0.539.0",
         "next": "14.2.5",
@@ -292,6 +293,24 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.17.0.tgz",
+      "integrity": "sha512-N2tnyKayT0Zf7mHjwEyE8iG7FwTmXDHFZ1GnNhQp0pJUObsuel4ZZ1XwfuAYkq5mRIiC/Kot0kt0tGCfLJ70Jw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
       }
     },
     "node_modules/@swc/counter": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint --no-error-on-unmatched-pattern"
   },
   "dependencies": {
+    "@prisma/client": "^5.17.0",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.539.0",
     "next": "14.2.5",


### PR DESCRIPTION
## Summary
- replace hardcoded admin check with Prisma-backed lookup
- verify passwords using scrypt hash and require `Admin` role
- add Prisma client dependency for web middleware

## Testing
- `npm run lint` *(fails: unknown option '--no-error-on-unmatched-pattern')*
- `npx next lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a711effb40832495fb57dc98f29f74