### PR TITLE
feat(api): seed admin and test users

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client'
 import { Logger } from '@nestjs/common'
-import { randomBytes, scryptSync } from 'crypto'
+import { randomBytes, scryptSync, timingSafeEqual } from 'crypto'
 
 const prisma = new PrismaClient()
 
@@ -8,6 +8,13 @@ function hashPassword(password: string): string {
   const salt = randomBytes(16).toString('hex')
   const hash = scryptSync(password, salt, 64).toString('hex')
   return `${salt}:${hash}`
+}
+
+function verifyPassword(password: string, storedHash: string): boolean {
+  const [salt, hash] = storedHash.split(':')
+  const hashedBuffer = scryptSync(password, salt, 64)
+  const hashBuffer = Buffer.from(hash, 'hex')
+  return timingSafeEqual(hashedBuffer, hashBuffer)
 }
 
 async function main() {
@@ -56,11 +63,22 @@ async function main() {
   }
 
   await prisma.user.upsert({
+    where: { email: 'admin@example.com' },
+    update: {},
+    create: {
+      email: 'admin@example.com',
+      passwordHash: hashPassword('admin'),
+      role: 'Admin'
+    }
+  })
+
+  await prisma.user.upsert({
     where: { email: 'test1@example.com' },
     update: {},
     create: {
       email: 'test1@example.com',
-      passkeyPub: hashPassword('pass1')
+      passwordHash: hashPassword('pass1'),
+      role: 'User'
     }
   })
 


### PR DESCRIPTION
## Summary
- add scrypt-based password hashing utilities
- seed admin@example.com and test1@example.com users with roles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a73fb9378c8324b145936579910efe