### PR TITLE
feat(web): add password utilities and secure landing API

### DIFF
--- a/apps/web/src/app/api/landing/route.ts
+++ b/apps/web/src/app/api/landing/route.ts
@@ -1,16 +1,50 @@
 import { NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { verifyPassword } from '@/lib/password';
 import {
   getLandingConfig,
   saveLandingConfig,
   type LandingConfig,
 } from '@/lib/landing';
 
-export function GET() {
+const prisma = new PrismaClient();
+
+function unauthorized() {
+  return new NextResponse('Unauthorized', {
+    status: 401,
+    headers: { 'WWW-Authenticate': 'Basic realm="Secure Area"' },
+  });
+}
+
+async function isAuthorized(req: Request): Promise<boolean> {
+  const auth = req.headers.get('authorization');
+  if (!auth) return false;
+  const [scheme, encoded] = auth.split(' ');
+  if (scheme !== 'Basic' || !encoded) return false;
+  let decoded: string;
+  try {
+    decoded =
+      typeof atob === 'function'
+        ? atob(encoded)
+        : Buffer.from(encoded, 'base64').toString('utf8');
+  } catch {
+    return false;
+  }
+  const [login, password] = decoded.split(':');
+  if (!login || !password) return false;
+  const admin = await prisma.adminUser.findUnique({ where: { email: login } });
+  if (!admin || admin.role !== 'Admin') return false;
+  return verifyPassword(password, admin.passwordHash);
+}
+
+export async function GET(request: Request) {
+  if (!(await isAuthorized(request))) return unauthorized();
   const config = getLandingConfig();
   return NextResponse.json(config);
 }
 
 export async function POST(request: Request) {
+  if (!(await isAuthorized(request))) return unauthorized();
   const body = (await request.json()) as Partial<LandingConfig>;
   const current = getLandingConfig();
   const newConfig: LandingConfig = {

--- a/apps/web/src/lib/password.ts
+++ b/apps/web/src/lib/password.ts
@@ -1,0 +1,18 @@
+import { randomBytes, scryptSync, timingSafeEqual } from 'crypto';
+
+export function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+  return `${salt}:${hash}`;
+}
+
+export function verifyPassword(password: string, hash: string): boolean {
+  const [salt, storedHash] = hash.split(':');
+  try {
+    const hashed = scryptSync(password, salt, 64);
+    const stored = Buffer.from(storedHash, 'hex');
+    return timingSafeEqual(hashed, stored);
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
-import { scryptSync, timingSafeEqual } from 'crypto';
+import { verifyPassword } from '@/lib/password';
 
 const prisma = new PrismaClient();
 
@@ -37,17 +37,6 @@ export async function middleware(req: NextRequest) {
   if (!verifyPassword(password, admin.passwordHash)) return unauthorized();
 
   return NextResponse.next();
-}
-
-function verifyPassword(password: string, hash: string): boolean {
-  const [salt, storedHash] = hash.split(':');
-  try {
-    const hashed = scryptSync(password, salt, 64);
-    const stored = Buffer.from(storedHash, 'hex');
-    return timingSafeEqual(hashed, stored);
-  } catch {
-    return false;
-  }
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- add password hash and verification helpers
- reuse verifyPassword in middleware
- secure landing API routes with basic auth

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: unknown option '--no-error-on-unmatched-pattern')*

------
https://chatgpt.com/codex/tasks/task_e_68a73fba48308324ba89f468f8ebe774