### PR TITLE
fix: avoid prisma in edge middleware

### DIFF
--- a/apps/web/src/app/api/landing/route.ts
+++ b/apps/web/src/app/api/landing/route.ts
@@ -37,6 +37,11 @@ async function isAuthorized(req: Request): Promise<boolean> {
   return await verifyPassword(password, admin.passwordHash);
 }
 
+export async function HEAD(request: Request) {
+  if (!(await isAuthorized(request))) return unauthorized();
+  return new NextResponse(null, { status: 200 });
+}
+
 export async function GET(request: Request) {
   if (!(await isAuthorized(request))) return unauthorized();
   const config = getLandingConfig();


### PR DESCRIPTION
## Summary
- delegate admin basic-auth middleware to internal API to avoid Prisma in Edge runtime
- expose lightweight HEAD handler for `/api/landing` auth checks

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: unknown option '--no-error-on-unmatched-pattern')*
- `npx next lint` *(fails: interactive prompt; no ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a80a78058c832480ed782eb3a51545