### PR TITLE
feat(api): add auth module and JWT guard

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -11,8 +11,10 @@
         "@nestjs/swagger": "^7.4.2",
         "@noble/hashes": "^1.8.0",
         "@prisma/client": "^5.17.0",
+        "@types/jsonwebtoken": "^9.0.10",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "jsonwebtoken": "^9.0.2",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "swagger-ui-express": "^5.0.1"
@@ -2348,6 +2350,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -2355,11 +2367,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
       "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
@@ -3113,6 +3130,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3796,6 +3819,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -6007,6 +6039,55 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -6069,11 +6150,53 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -7242,7 +7365,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8227,7 +8349,6 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,8 +18,10 @@
     "@nestjs/swagger": "^7.4.2",
     "@noble/hashes": "^1.8.0",
     "@prisma/client": "^5.17.0",
+    "@types/jsonwebtoken": "^9.0.10",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "jsonwebtoken": "^9.0.2",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1"

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,10 +10,12 @@ import { NotificationsModule } from './notifications/notifications.module';
 import { OrchestratorModule } from './orchestrator/orchestrator.module';
 import { HeartbeatsModule } from './heartbeats/heartbeats.module';
 import { HealthModule } from './health/health.module';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
 imports: [
   PrismaModule,
+  AuthModule,
   VaultsModule,
   VerifiersModule,
   VerificationEventsModule,

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,0 +1,12 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly auth: AuthService) {}
+
+  @Post('login')
+  login(@Body('userId') userId: string) {
+    return { access_token: this.auth.sign(userId) };
+  }
+}

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+@Module({
+  controllers: [AuthController],
+  providers: [AuthService, JwtAuthGuard],
+  exports: [AuthService, JwtAuthGuard],
+})
+export class AuthModule {}

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class AuthService {
+  private readonly secret = process.env.JWT_SECRET || 'secret';
+
+  sign(userId: string): string {
+    return jwt.sign({ sub: userId }, this.secret, { expiresIn: '1h' });
+  }
+
+  verify(token: string): any {
+    try {
+      return jwt.verify(token, this.secret);
+    } catch (e) {
+      return null;
+    }
+  }
+}

--- a/apps/api/src/auth/jwt-auth.guard.ts
+++ b/apps/api/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,22 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  constructor(private readonly auth: AuthService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest();
+    const authHeader = req.headers['authorization'] || '';
+    const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    if (!token) {
+      throw new UnauthorizedException();
+    }
+    const payload = this.auth.verify(token);
+    if (!payload) {
+      throw new UnauthorizedException();
+    }
+    req.user = payload;
+    return true;
+  }
+}

--- a/apps/api/src/blocks/blocks.controller.ts
+++ b/apps/api/src/blocks/blocks.controller.ts
@@ -1,39 +1,41 @@
-import { Controller, Get, Post, Delete, Param, Body, Query, ParseUUIDPipe } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Param, Body, Query, ParseUUIDPipe, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiParam } from '@nestjs/swagger';
 import { BlocksService } from './blocks.service';
 import { CreateBlockDto } from './dto/create-block.dto';
 import { AssignRecipientDto } from './dto/assign-recipient.dto';
-import { CurrentUserId } from '../common/current-user.decorator';
+import { CurrentUser } from '../common/current-user.decorator';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('blocks')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('blocks')
 export class BlocksController {
   constructor(private readonly service: BlocksService) {}
 
   @Get()
   list(
-    @CurrentUserId() userId: string,
+    @CurrentUser() user: any,
     @Query('vault_id') vaultId: string,
     @Query('cursor') cursor?: string,
     @Query('limit') limit?: number,
   ) {
-    return this.service.list(userId, vaultId, cursor, Number(limit) || 50);
+    return this.service.list(user.sub, vaultId, cursor, Number(limit) || 50);
   }
 
   @Get(':id')
-  get(@CurrentUserId() userId: string, @Param('id') id: string) {
-    return this.service.get(userId, id);
+  get(@CurrentUser() user: any, @Param('id') id: string) {
+    return this.service.get(user.sub, id);
   }
 
   @Post()
-  create(@CurrentUserId() userId: string, @Body() dto: CreateBlockDto) {
-    return this.service.create(userId, dto);
+  create(@CurrentUser() user: any, @Body() dto: CreateBlockDto) {
+    return this.service.create(user.sub, dto);
   }
 
   @Delete(':id')
-  async remove(@CurrentUserId() userId: string, @Param('id') id: string) {
-    await this.service.softDelete(userId, id);
+  async remove(@CurrentUser() user: any, @Param('id') id: string) {
+    await this.service.softDelete(user.sub, id);
     return { status: 'ok' };
   }
 
@@ -41,20 +43,20 @@ export class BlocksController {
   @ApiOperation({ summary: 'List recipients assigned to a block' })
   @ApiParam({ name: 'id', format: 'uuid' })
   listRecipients(
-    @CurrentUserId() userId: string,
+    @CurrentUser() user: any,
     @Param('id', ParseUUIDPipe) id: string,
   ) {
-    return this.service.listRecipients(userId, id);
+    return this.service.listRecipients(user.sub, id);
   }
 
   @Post(':id/recipients')
   @ApiOperation({ summary: 'Assign a recipient to a block' })
   @ApiParam({ name: 'id', format: 'uuid' })
   assignRecipient(
-    @CurrentUserId() userId: string,
+    @CurrentUser() user: any,
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: AssignRecipientDto,
   ) {
-    return this.service.assignRecipient(userId, id, dto);
+    return this.service.assignRecipient(user.sub, id, dto);
   }
 }

--- a/apps/api/src/blocks/blocks.module.ts
+++ b/apps/api/src/blocks/blocks.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { BlocksService } from './blocks.service';
 import { BlocksController } from './blocks.controller';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
+  imports: [AuthModule],
   controllers: [BlocksController],
   providers: [BlocksService],
   exports: [BlocksService],

--- a/apps/api/src/common/current-user.decorator.ts
+++ b/apps/api/src/common/current-user.decorator.ts
@@ -1,14 +1,13 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
-/**
- * Temporary helper until real Auth is wired.
- * Reads user id from `x-debug-user` header or env DEFAULT_DEBUG_USER.
- */
-export const CurrentUserId = createParamDecorator(
-  (_data: unknown, ctx: ExecutionContext) => {
+export interface AuthenticatedUser {
+  sub: string;
+  [key: string]: any;
+}
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): AuthenticatedUser => {
     const req = ctx.switchToHttp().getRequest();
-    const header = (req.headers['x-debug-user'] || '').toString();
-    const fallback = process.env.DEFAULT_DEBUG_USER || null;
-    return header || fallback;
+    return req.user;
   },
 );

--- a/apps/api/src/heartbeats/heartbeats.controller.ts
+++ b/apps/api/src/heartbeats/heartbeats.controller.ts
@@ -1,32 +1,34 @@
-import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { HeartbeatsService } from './heartbeats.service';
 import { UpdateHeartbeatDto } from './dto/update-heartbeat.dto';
 import { HeartbeatPingDto } from './dto/ping.dto';
-import { CurrentUserId } from '../common/current-user.decorator';
+import { CurrentUser } from '../common/current-user.decorator';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('heartbeats')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller()
 export class HeartbeatsController {
   constructor(private readonly service: HeartbeatsService) {}
 
   @Get('vaults/:vaultId/heartbeat')
-  getConfig(@CurrentUserId() userId: string, @Param('vaultId') vaultId: string) {
-    return this.service.getConfig(userId, vaultId);
+  getConfig(@CurrentUser() user: any, @Param('vaultId') vaultId: string) {
+    return this.service.getConfig(user.sub, vaultId);
   }
 
   @Patch('vaults/:vaultId/heartbeat')
   updateConfig(
-    @CurrentUserId() userId: string,
+    @CurrentUser() user: any,
     @Param('vaultId') vaultId: string,
     @Body() dto: UpdateHeartbeatDto,
   ) {
-    return this.service.updateConfig(userId, vaultId, dto);
+    return this.service.updateConfig(user.sub, vaultId, dto);
   }
 
   @Post('heartbeats/ping')
-  ping(@CurrentUserId() userId: string, @Body() dto: HeartbeatPingDto) {
-    return this.service.ping(userId, dto.vault_id, dto.method);
+  ping(@CurrentUser() user: any, @Body() dto: HeartbeatPingDto) {
+    return this.service.ping(user.sub, dto.vault_id, dto.method);
   }
 }

--- a/apps/api/src/heartbeats/heartbeats.module.ts
+++ b/apps/api/src/heartbeats/heartbeats.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { HeartbeatsService } from './heartbeats.service';
 import { HeartbeatsController } from './heartbeats.controller';
 import { HeartbeatProcessor } from './heartbeats.processor';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
+  imports: [AuthModule],
   controllers: [HeartbeatsController],
   providers: [HeartbeatsService, HeartbeatProcessor],
   exports: [HeartbeatsService],

--- a/apps/api/src/orchestrator/orchestrator.controller.ts
+++ b/apps/api/src/orchestrator/orchestrator.controller.ts
@@ -1,23 +1,25 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { OrchestratorService } from './orchestrator.service';
 import { StartEventDto } from './dto/start-event.dto';
 import { DecisionDto } from './dto/decision.dto';
-import { CurrentUserId } from '../common/current-user.decorator';
+import { CurrentUser } from '../common/current-user.decorator';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('orchestrator')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('orchestration')
 export class OrchestratorController {
   constructor(private readonly svc: OrchestratorService) {}
 
   @Post('start')
-  start(@CurrentUserId() userId: string, @Body() dto: StartEventDto) {
-    return this.svc.start(userId, dto.vault_id);
+  start(@CurrentUser() user: any, @Body() dto: StartEventDto) {
+    return this.svc.start(user.sub, dto.vault_id);
   }
 
   @Post('decision')
-  decide(@CurrentUserId() _userId: string, @Body() dto: DecisionDto) {
+  decide(@CurrentUser() _user: any, @Body() dto: DecisionDto) {
     return this.svc.decide(dto.vault_id, dto.verifier_id, dto.decision, dto.signature);
   }
 }

--- a/apps/api/src/orchestrator/orchestrator.module.ts
+++ b/apps/api/src/orchestrator/orchestrator.module.ts
@@ -4,9 +4,10 @@ import { OrchestratorController } from './orchestrator.controller';
 import { OrchestratorProcessor } from './orchestrator.processor';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { PrismaModule } from '../prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [NotificationsModule, PrismaModule],
+  imports: [NotificationsModule, PrismaModule, AuthModule],
   controllers: [OrchestratorController],
   providers: [OrchestratorService, OrchestratorProcessor],
   exports: [OrchestratorService],

--- a/apps/api/src/public-links/public-links.controller.ts
+++ b/apps/api/src/public-links/public-links.controller.ts
@@ -1,27 +1,29 @@
-import { Body, Controller, Delete, Get, Param, Put } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Put, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { PublicLinksService } from './public-links.service';
 import { UpdatePublicLinkDto } from './dto/update-public-link.dto';
-import { CurrentUserId } from '../common/current-user.decorator';
+import { CurrentUser } from '../common/current-user.decorator';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('public-links')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('blocks/:id/public')
 export class PublicLinksController {
   constructor(private readonly service: PublicLinksService) {}
 
   @Get()
-  get(@CurrentUserId() userId: string, @Param('id') blockId: string) {
-    return this.service.getForBlock(userId, blockId);
+  get(@CurrentUser() user: any, @Param('id') blockId: string) {
+    return this.service.getForBlock(user.sub, blockId);
   }
 
   @Put()
-  upsert(@CurrentUserId() userId: string, @Param('id') blockId: string, @Body() dto: UpdatePublicLinkDto) {
-    return this.service.upsert(userId, blockId, dto);
+  upsert(@CurrentUser() user: any, @Param('id') blockId: string, @Body() dto: UpdatePublicLinkDto) {
+    return this.service.upsert(user.sub, blockId, dto);
   }
 
   @Delete()
-  disable(@CurrentUserId() userId: string, @Param('id') blockId: string) {
-    return this.service.disable(userId, blockId);
+  disable(@CurrentUser() user: any, @Param('id') blockId: string) {
+    return this.service.disable(user.sub, blockId);
   }
 }

--- a/apps/api/src/public-links/public-links.module.ts
+++ b/apps/api/src/public-links/public-links.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { PublicLinksService } from './public-links.service';
 import { PublicLinksController } from './public-links.controller';
 import { PublicAccessController } from './public.controller';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
+  imports: [AuthModule],
   controllers: [PublicLinksController, PublicAccessController],
   providers: [PublicLinksService],
   exports: [PublicLinksService],

--- a/apps/api/src/recipients/recipients.controller.ts
+++ b/apps/api/src/recipients/recipients.controller.ts
@@ -1,11 +1,13 @@
-import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { RecipientsService } from './recipients.service';
 import { CreateRecipientDto } from './dto/create-recipient.dto';
 import { SearchRecipientsDto } from './dto/search-recipients.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('recipients')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('recipients')
 export class RecipientsController {
   constructor(private readonly service: RecipientsService) {}

--- a/apps/api/src/recipients/recipients.module.ts
+++ b/apps/api/src/recipients/recipients.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { RecipientsService } from './recipients.service';
 import { RecipientsController } from './recipients.controller';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
+  imports: [AuthModule],
   controllers: [RecipientsController],
   providers: [RecipientsService],
   exports: [RecipientsService],

--- a/apps/api/src/vaults/vaults.controller.ts
+++ b/apps/api/src/vaults/vaults.controller.ts
@@ -1,41 +1,43 @@
-import { Controller, Get, Post, Body, Param, Query, Patch } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Query, Patch, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { VaultsService } from './vaults.service';
 import { CreateVaultDto } from './dto/create-vault.dto';
 import { UpdateVaultSettingsDto } from './dto/update-vault-settings.dto';
-import { CurrentUserId } from '../common/current-user.decorator';
+import { CurrentUser } from '../common/current-user.decorator';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('vaults')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('vaults')
 export class VaultsController {
   constructor(private readonly service: VaultsService) {}
 
   @Get()
   list(
-    @CurrentUserId() userId: string,
+    @CurrentUser() user: any,
     @Query('cursor') cursor?: string,
     @Query('limit') limit?: number,
   ) {
-    return this.service.listForUser(userId, cursor, Number(limit) || 50);
+    return this.service.listForUser(user.sub, cursor, Number(limit) || 50);
   }
 
   @Get(':id')
-  get(@CurrentUserId() userId: string, @Param('id') id: string) {
-    return this.service.getForUser(userId, id);
+  get(@CurrentUser() user: any, @Param('id') id: string) {
+    return this.service.getForUser(user.sub, id);
   }
 
   @Post()
-  create(@CurrentUserId() userId: string, @Body() dto: CreateVaultDto) {
-    return this.service.createForUser(userId, dto);
+  create(@CurrentUser() user: any, @Body() dto: CreateVaultDto) {
+    return this.service.createForUser(user.sub, dto);
   }
 
   @Patch(':id/settings')
   updateSettings(
-    @CurrentUserId() userId: string,
+    @CurrentUser() user: any,
     @Param('id') id: string,
     @Body() dto: UpdateVaultSettingsDto,
   ) {
-    return this.service.updateSettings(userId, id, dto);
+    return this.service.updateSettings(user.sub, id, dto);
   }
 }

--- a/apps/api/src/vaults/vaults.module.ts
+++ b/apps/api/src/vaults/vaults.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { VaultsService } from './vaults.service';
 import { VaultsController } from './vaults.controller';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
+  imports: [AuthModule],
   controllers: [VaultsController],
   providers: [VaultsService],
   exports: [VaultsService],

--- a/apps/api/src/verifiers/verifiers.controller.ts
+++ b/apps/api/src/verifiers/verifiers.controller.ts
@@ -1,11 +1,13 @@
-import { Controller, Get, Post, Body, Query, Param } from '@nestjs/common';
+import { Controller, Get, Post, Body, Query, Param, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { randomBytes } from 'crypto';
 import { VerifiersService } from './verifiers.service';
 import { InviteVerifierDto } from './dto/invite-verifier.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('verifiers')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('verifiers')
 export class VerifiersController {
   constructor(private readonly service: VerifiersService) {}

--- a/apps/api/src/verifiers/verifiers.module.ts
+++ b/apps/api/src/verifiers/verifiers.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { VerifiersService } from './verifiers.service';
 import { VerifiersController } from './verifiers.controller';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [NotificationsModule],
+  imports: [NotificationsModule, AuthModule],
   controllers: [VerifiersController],
   providers: [VerifiersService],
   exports: [VerifiersService],


### PR DESCRIPTION
## Summary
- add auth module with JWT-based login and guard
- expose `CurrentUser` decorator backed by validated tokens
- secure API controllers with `JwtAuthGuard`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2aa8ea3088324a4ad7378f25adf9f