### PR TITLE
feat: add global auth guard for API

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
-import { JwtAuthGuard } from './jwt-auth.guard';
+import { AuthGuard } from './guards/auth.guard';
 
 @Module({
   controllers: [AuthController],
-  providers: [AuthService, JwtAuthGuard],
-  exports: [AuthService, JwtAuthGuard],
+  providers: [AuthService, AuthGuard],
+  exports: [AuthService, AuthGuard],
 })
 export class AuthModule {}

--- a/apps/api/src/auth/guards/auth.guard.ts
+++ b/apps/api/src/auth/guards/auth.guard.ts
@@ -1,12 +1,16 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
-import { AuthService } from './auth.service';
+import { AuthService } from '../auth.service';
 
 @Injectable()
-export class JwtAuthGuard implements CanActivate {
+export class AuthGuard implements CanActivate {
   constructor(private readonly auth: AuthService) {}
 
   canActivate(context: ExecutionContext): boolean {
     const req = context.switchToHttp().getRequest();
+    const openPaths = ['/auth/login', '/healthz', '/readyz'];
+    if (openPaths.includes(req.path)) {
+      return true;
+    }
     const authHeader = req.headers['authorization'] || '';
     const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
     if (!token) {

--- a/apps/api/src/blocks/blocks.controller.ts
+++ b/apps/api/src/blocks/blocks.controller.ts
@@ -1,14 +1,12 @@
-import { Controller, Get, Post, Delete, Param, Body, Query, ParseUUIDPipe, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Param, Body, Query, ParseUUIDPipe } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiParam } from '@nestjs/swagger';
 import { BlocksService } from './blocks.service';
 import { CreateBlockDto } from './dto/create-block.dto';
 import { AssignRecipientDto } from './dto/assign-recipient.dto';
 import { CurrentUser } from '../common/current-user.decorator';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('blocks')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
 @Controller('blocks')
 export class BlocksController {
   constructor(private readonly service: BlocksService) {}

--- a/apps/api/src/heartbeats/heartbeats.controller.ts
+++ b/apps/api/src/heartbeats/heartbeats.controller.ts
@@ -1,14 +1,12 @@
-import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { HeartbeatsService } from './heartbeats.service';
 import { UpdateHeartbeatDto } from './dto/update-heartbeat.dto';
 import { HeartbeatPingDto } from './dto/ping.dto';
 import { CurrentUser } from '../common/current-user.decorator';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('heartbeats')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
 @Controller()
 export class HeartbeatsController {
   constructor(private readonly service: HeartbeatsService) {}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { PrismaService } from './prisma/prisma.service';
+import { AuthGuard } from './auth/guards/auth.guard';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -13,6 +14,8 @@ async function bootstrap() {
     transform: true,
     forbidUnknownValues: false,
   }));
+
+  app.useGlobalGuards(app.get(AuthGuard));
 
   const config = new DocumentBuilder()
     .setTitle('AfterLight API')

--- a/apps/api/src/orchestrator/orchestrator.controller.ts
+++ b/apps/api/src/orchestrator/orchestrator.controller.ts
@@ -1,14 +1,12 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { OrchestratorService } from './orchestrator.service';
 import { StartEventDto } from './dto/start-event.dto';
 import { DecisionDto } from './dto/decision.dto';
 import { CurrentUser } from '../common/current-user.decorator';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('orchestrator')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
 @Controller('orchestration')
 export class OrchestratorController {
   constructor(private readonly svc: OrchestratorService) {}

--- a/apps/api/src/public-links/public-links.controller.ts
+++ b/apps/api/src/public-links/public-links.controller.ts
@@ -1,13 +1,11 @@
-import { Body, Controller, Delete, Get, Param, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Put } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { PublicLinksService } from './public-links.service';
 import { UpdatePublicLinkDto } from './dto/update-public-link.dto';
 import { CurrentUser } from '../common/current-user.decorator';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('public-links')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
 @Controller('blocks/:id/public')
 export class PublicLinksController {
   constructor(private readonly service: PublicLinksService) {}

--- a/apps/api/src/recipients/recipients.controller.ts
+++ b/apps/api/src/recipients/recipients.controller.ts
@@ -1,13 +1,11 @@
-import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { RecipientsService } from './recipients.service';
 import { CreateRecipientDto } from './dto/create-recipient.dto';
 import { SearchRecipientsDto } from './dto/search-recipients.dto';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('recipients')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
 @Controller('recipients')
 export class RecipientsController {
   constructor(private readonly service: RecipientsService) {}

--- a/apps/api/src/vaults/vaults.controller.ts
+++ b/apps/api/src/vaults/vaults.controller.ts
@@ -1,14 +1,12 @@
-import { Controller, Get, Post, Body, Param, Query, Patch, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Query, Patch } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { VaultsService } from './vaults.service';
 import { CreateVaultDto } from './dto/create-vault.dto';
 import { UpdateVaultSettingsDto } from './dto/update-vault-settings.dto';
 import { CurrentUser } from '../common/current-user.decorator';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('vaults')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
 @Controller('vaults')
 export class VaultsController {
   constructor(private readonly service: VaultsService) {}

--- a/apps/api/src/vaults/vaults.service.ts
+++ b/apps/api/src/vaults/vaults.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateVaultDto } from './dto/create-vault.dto';
 import { UpdateVaultSettingsDto } from './dto/update-vault-settings.dto';
@@ -9,7 +9,6 @@ export class VaultsService {
   constructor(private prisma: PrismaService) {}
 
   async listForUser(userId: string, cursor?: string, limit = 50) {
-    if (!userId) throw new UnauthorizedException('No user');
     const take = Math.min(Math.max(Number(limit) || 50, 1), 200);
     return this.prisma.vault.findMany({
       where: { userId },
@@ -20,14 +19,12 @@ export class VaultsService {
   }
 
   async getForUser(userId: string, id: string) {
-    if (!userId) throw new UnauthorizedException('No user');
     const v = await this.prisma.vault.findFirst({ where: { id, userId } });
     if (!v) throw new NotFoundException('Vault not found');
     return v;
   }
 
   async createForUser(userId: string, dto: CreateVaultDto) {
-    if (!userId) throw new UnauthorizedException('No user');
     const defaults = {
       quorumThreshold: 3,
       maxVerifiers: 5,
@@ -51,7 +48,6 @@ export class VaultsService {
   }
 
   async updateSettings(userId: string, id: string, dto: UpdateVaultSettingsDto) {
-    if (!userId) throw new UnauthorizedException('No user');
     await this.getForUser(userId, id);
     if (dto.primary_verifier_id) {
       await this.prisma.$transaction([

--- a/apps/api/src/verifiers/verifiers.controller.ts
+++ b/apps/api/src/verifiers/verifiers.controller.ts
@@ -1,13 +1,11 @@
-import { Controller, Get, Post, Body, Query, Param, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Body, Query, Param } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { randomBytes } from 'crypto';
 import { VerifiersService } from './verifiers.service';
 import { InviteVerifierDto } from './dto/invite-verifier.dto';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @ApiTags('verifiers')
 @ApiBearerAuth()
-@UseGuards(JwtAuthGuard)
 @Controller('verifiers')
 export class VerifiersController {
   constructor(private readonly service: VerifiersService) {}

--- a/apps/api/test/vaults.service.spec.ts
+++ b/apps/api/test/vaults.service.spec.ts
@@ -1,6 +1,6 @@
 import { VaultsService } from '../src/vaults/vaults.service';
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { UnauthorizedException, NotFoundException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 
 describe('VaultsService', () => {
   let prisma: any;
@@ -23,10 +23,6 @@ describe('VaultsService', () => {
     expect(passed.userId).toBe('u1');
     expect(passed.mkWrapped).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
     expect(res.mkWrapped).toBe(passed.mkWrapped);
-  });
-
-  it('throws Unauthorized when user id missing', async () => {
-    await expect(service.createForUser('', {} as any)).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
   it('throws NotFound when vault not found', async () => {


### PR DESCRIPTION
## Summary
- add JWT-authenticating `AuthGuard` and apply globally
- drop explicit `userId` checks in services
- update controllers and tests to rely on guard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2abf1b23083249b4bf5c68ff831fc