### PR TITLE
chore(api): remove obsolete modules directory

### DIFF
--- a/apps/api/src/modules/blocks/controller.ts
+++ b/apps/api/src/modules/blocks/controller.ts
@@ -1,7 +1,0 @@
-// blocks controller stub — replace with NestJS controllers later
-// GET /blocks?vault_id
-// POST /blocks (multipart)
-// GET /blocks/{id}
-// DELETE /blocks/{id}
-// GET/POST /blocks/{id}/recipients
-// PUT /blocks/{id}/public

--- a/apps/api/src/modules/heartbeats/controller.ts
+++ b/apps/api/src/modules/heartbeats/controller.ts
@@ -1,2 +1,0 @@
-// heartbeats controller stub — replace with NestJS controllers later
-// POST /heartbeats/ping

--- a/apps/api/src/modules/recipients/controller.ts
+++ b/apps/api/src/modules/recipients/controller.ts
@@ -1,2 +1,0 @@
-// recipients controller stub — replace with NestJS controllers later
-// POST /recipients

--- a/apps/api/src/modules/vaults/controller.ts
+++ b/apps/api/src/modules/vaults/controller.ts
@@ -1,5 +1,0 @@
-// vaults controller stub — replace with NestJS controllers later
-// GET /vaults
-// POST /vaults
-// GET /vaults/{id}
-// PATCH /vaults/{id}/settings

--- a/apps/api/src/modules/verification-events/controller.ts
+++ b/apps/api/src/modules/verification-events/controller.ts
@@ -1,7 +1,0 @@
-// verification-events controller stub — replace with NestJS controllers later
-// POST /verification-events
-// GET /verification-events?vault_id
-// GET /verification-events/{id}
-// POST /verification-events/{id}/confirm
-// POST /verification-events/{id}/deny
-// POST /verification-events/{id}/abort

--- a/apps/api/src/modules/verifiers/controller.ts
+++ b/apps/api/src/modules/verifiers/controller.ts
@@ -1,4 +1,0 @@
-// verifiers controller stub — replace with NestJS controllers later
-// GET /verifiers?vault_id
-// POST /verifiers/invitations
-// POST /verifiers/invitations/{vaultId}/{verifierId}/accept


### PR DESCRIPTION
## Summary
- remove outdated `apps/api/src/modules` controllers
- confirm no remaining imports reference removed path

## Testing
- `cd apps/api && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2ad719d3483249fd897828e0f78ca