### PR TITLE
feat(api): add core management modules

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -11,6 +11,11 @@ import { OrchestratorModule } from './orchestrator/orchestrator.module';
 import { HeartbeatsModule } from './heartbeats/heartbeats.module';
 import { HealthModule } from './health/health.module';
 import { AuthModule } from './auth/auth.module';
+import { UsersModule } from './users/users.module';
+import { PlansModule } from './plans/plans.module';
+import { SubscriptionsModule } from './subscriptions/subscriptions.module';
+import { AuditLogsModule } from './audit-logs/audit-logs.module';
+import { RecoverySharesModule } from './recovery-shares/recovery-shares.module';
 
 @Module({
 imports: [
@@ -26,6 +31,11 @@ imports: [
   NotificationsModule,
   OrchestratorModule,
   HealthModule,
+  UsersModule,
+  PlansModule,
+  SubscriptionsModule,
+  AuditLogsModule,
+  RecoverySharesModule,
 ],
 })
 export class AppModule {}

--- a/apps/api/src/audit-logs/audit-logs.controller.ts
+++ b/apps/api/src/audit-logs/audit-logs.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { AuditLogsService } from './audit-logs.service';
+import { CreateAuditLogDto } from './dto/create-audit-log.dto';
+import { UpdateAuditLogDto } from './dto/update-audit-log.dto';
+
+@ApiTags('audit-logs')
+@ApiBearerAuth()
+@Controller('audit-logs')
+export class AuditLogsController {
+  constructor(private readonly service: AuditLogsService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.service.get(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateAuditLogDto) {
+    return this.service.create(dto);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateAuditLogDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/apps/api/src/audit-logs/audit-logs.module.ts
+++ b/apps/api/src/audit-logs/audit-logs.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AuditLogsService } from './audit-logs.service';
+import { AuditLogsController } from './audit-logs.controller';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [AuditLogsController],
+  providers: [AuditLogsService],
+})
+export class AuditLogsModule {}

--- a/apps/api/src/audit-logs/audit-logs.service.ts
+++ b/apps/api/src/audit-logs/audit-logs.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateAuditLogDto } from './dto/create-audit-log.dto';
+import { UpdateAuditLogDto } from './dto/update-audit-log.dto';
+
+@Injectable()
+export class AuditLogsService {
+  constructor(private prisma: PrismaService) {}
+
+  list() {
+    return this.prisma.auditLog.findMany({ orderBy: { ts: 'desc' } });
+  }
+
+  get(id: string) {
+    return this.prisma.auditLog.findUnique({ where: { id } });
+  }
+
+  create(dto: CreateAuditLogDto) {
+    return this.prisma.auditLog.create({ data: dto });
+  }
+
+  update(id: string, dto: UpdateAuditLogDto) {
+    return this.prisma.auditLog.update({ where: { id }, data: dto });
+  }
+
+  remove(id: string) {
+    return this.prisma.auditLog.delete({ where: { id } });
+  }
+}

--- a/apps/api/src/audit-logs/dto/create-audit-log.dto.ts
+++ b/apps/api/src/audit-logs/dto/create-audit-log.dto.ts
@@ -5,15 +5,15 @@ import { IsEnum, IsOptional, IsString } from 'class-validator';
 export class CreateAuditLogDto {
   @ApiProperty({ enum: ActorType })
   @IsEnum(ActorType)
-  actorType: ActorType;
+  actorType!: ActorType;
 
   @ApiProperty()
   @IsString()
-  actorId: string;
+  actorId!: string;
 
   @ApiProperty()
   @IsString()
-  action: string;
+  action!: string;
 
   @ApiProperty({ required: false })
   @IsOptional()

--- a/apps/api/src/audit-logs/dto/create-audit-log.dto.ts
+++ b/apps/api/src/audit-logs/dto/create-audit-log.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ActorType } from '@prisma/client';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+
+export class CreateAuditLogDto {
+  @ApiProperty({ enum: ActorType })
+  @IsEnum(ActorType)
+  actorType: ActorType;
+
+  @ApiProperty()
+  @IsString()
+  actorId: string;
+
+  @ApiProperty()
+  @IsString()
+  action: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  targetId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  targetType?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  hash?: string;
+}

--- a/apps/api/src/audit-logs/dto/update-audit-log.dto.ts
+++ b/apps/api/src/audit-logs/dto/update-audit-log.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateAuditLogDto } from './create-audit-log.dto';
+
+export class UpdateAuditLogDto extends PartialType(CreateAuditLogDto) {}

--- a/apps/api/src/plans/dto/create-plan.dto.ts
+++ b/apps/api/src/plans/dto/create-plan.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PlanTier } from '@prisma/client';
+import { IsEnum, IsOptional } from 'class-validator';
+
+export class CreatePlanDto {
+  @ApiProperty({ enum: PlanTier })
+  @IsEnum(PlanTier)
+  tier: PlanTier;
+
+  @ApiProperty({ type: Object })
+  @IsOptional()
+  limits?: Record<string, any>;
+}

--- a/apps/api/src/plans/dto/create-plan.dto.ts
+++ b/apps/api/src/plans/dto/create-plan.dto.ts
@@ -5,7 +5,7 @@ import { IsEnum, IsOptional } from 'class-validator';
 export class CreatePlanDto {
   @ApiProperty({ enum: PlanTier })
   @IsEnum(PlanTier)
-  tier: PlanTier;
+  tier!: PlanTier;
 
   @ApiProperty({ type: Object })
   @IsOptional()

--- a/apps/api/src/plans/dto/update-plan.dto.ts
+++ b/apps/api/src/plans/dto/update-plan.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreatePlanDto } from './create-plan.dto';
+
+export class UpdatePlanDto extends PartialType(CreatePlanDto) {}

--- a/apps/api/src/plans/plans.controller.ts
+++ b/apps/api/src/plans/plans.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { PlansService } from './plans.service';
+import { CreatePlanDto } from './dto/create-plan.dto';
+import { UpdatePlanDto } from './dto/update-plan.dto';
+
+@ApiTags('plans')
+@ApiBearerAuth()
+@Controller('plans')
+export class PlansController {
+  constructor(private readonly service: PlansService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.service.get(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreatePlanDto) {
+    return this.service.create(dto);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdatePlanDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/apps/api/src/plans/plans.module.ts
+++ b/apps/api/src/plans/plans.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PlansService } from './plans.service';
+import { PlansController } from './plans.controller';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [PlansController],
+  providers: [PlansService],
+})
+export class PlansModule {}

--- a/apps/api/src/plans/plans.service.ts
+++ b/apps/api/src/plans/plans.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreatePlanDto } from './dto/create-plan.dto';
+import { UpdatePlanDto } from './dto/update-plan.dto';
+
+@Injectable()
+export class PlansService {
+  constructor(private prisma: PrismaService) {}
+
+  list() {
+    return this.prisma.plan.findMany();
+  }
+
+  get(id: string) {
+    return this.prisma.plan.findUnique({ where: { id } });
+  }
+
+  create(dto: CreatePlanDto) {
+    return this.prisma.plan.create({ data: { tier: dto.tier, limits: dto.limits ?? {} } });
+  }
+
+  update(id: string, dto: UpdatePlanDto) {
+    return this.prisma.plan.update({ where: { id }, data: dto });
+  }
+
+  remove(id: string) {
+    return this.prisma.plan.delete({ where: { id } });
+  }
+}

--- a/apps/api/src/recovery-shares/dto/create-recovery-share.dto.ts
+++ b/apps/api/src/recovery-shares/dto/create-recovery-share.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsString } from 'class-validator';
+
+export class CreateRecoveryShareDto {
+  @ApiProperty()
+  @IsString()
+  vaultId: string;
+
+  @ApiProperty()
+  @IsInt()
+  shareIndex: number;
+
+  @ApiProperty()
+  @IsString()
+  shareCipher: string;
+}

--- a/apps/api/src/recovery-shares/dto/create-recovery-share.dto.ts
+++ b/apps/api/src/recovery-shares/dto/create-recovery-share.dto.ts
@@ -4,13 +4,13 @@ import { IsInt, IsString } from 'class-validator';
 export class CreateRecoveryShareDto {
   @ApiProperty()
   @IsString()
-  vaultId: string;
+  vaultId!: string;
 
   @ApiProperty()
   @IsInt()
-  shareIndex: number;
+  shareIndex!: number;
 
   @ApiProperty()
   @IsString()
-  shareCipher: string;
+  shareCipher!: string;
 }

--- a/apps/api/src/recovery-shares/dto/update-recovery-share.dto.ts
+++ b/apps/api/src/recovery-shares/dto/update-recovery-share.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateRecoveryShareDto } from './create-recovery-share.dto';
+
+export class UpdateRecoveryShareDto extends PartialType(CreateRecoveryShareDto) {}

--- a/apps/api/src/recovery-shares/recovery-shares.controller.ts
+++ b/apps/api/src/recovery-shares/recovery-shares.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { RecoverySharesService } from './recovery-shares.service';
+import { CreateRecoveryShareDto } from './dto/create-recovery-share.dto';
+import { UpdateRecoveryShareDto } from './dto/update-recovery-share.dto';
+
+@ApiTags('recovery-shares')
+@ApiBearerAuth()
+@Controller('recovery-shares')
+export class RecoverySharesController {
+  constructor(private readonly service: RecoverySharesService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.service.get(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateRecoveryShareDto) {
+    return this.service.create(dto);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateRecoveryShareDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/apps/api/src/recovery-shares/recovery-shares.module.ts
+++ b/apps/api/src/recovery-shares/recovery-shares.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { RecoverySharesService } from './recovery-shares.service';
+import { RecoverySharesController } from './recovery-shares.controller';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [RecoverySharesController],
+  providers: [RecoverySharesService],
+})
+export class RecoverySharesModule {}

--- a/apps/api/src/recovery-shares/recovery-shares.service.ts
+++ b/apps/api/src/recovery-shares/recovery-shares.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateRecoveryShareDto } from './dto/create-recovery-share.dto';
+import { UpdateRecoveryShareDto } from './dto/update-recovery-share.dto';
+
+@Injectable()
+export class RecoverySharesService {
+  constructor(private prisma: PrismaService) {}
+
+  list() {
+    return this.prisma.recoveryShare.findMany();
+  }
+
+  get(id: string) {
+    return this.prisma.recoveryShare.findUnique({ where: { id } });
+  }
+
+  create(dto: CreateRecoveryShareDto) {
+    return this.prisma.recoveryShare.create({ data: dto });
+  }
+
+  update(id: string, dto: UpdateRecoveryShareDto) {
+    return this.prisma.recoveryShare.update({ where: { id }, data: dto });
+  }
+
+  remove(id: string) {
+    return this.prisma.recoveryShare.delete({ where: { id } });
+  }
+}

--- a/apps/api/src/subscriptions/dto/create-subscription.dto.ts
+++ b/apps/api/src/subscriptions/dto/create-subscription.dto.ts
@@ -5,17 +5,17 @@ import { IsEnum, IsOptional, IsString, IsDateString } from 'class-validator';
 export class CreateSubscriptionDto {
   @ApiProperty()
   @IsString()
-  userId: string;
+  userId!: string;
 
   @ApiProperty()
   @IsString()
-  planId: string;
+  planId!: string;
 
   @ApiProperty({ enum: SubscriptionStatus })
   @IsEnum(SubscriptionStatus)
-  status: SubscriptionStatus;
+  status!: SubscriptionStatus;
 
   @ApiProperty({ type: String })
   @IsDateString()
-  currentPeriodEnd: string;
+  currentPeriodEnd!: string;
 }

--- a/apps/api/src/subscriptions/dto/create-subscription.dto.ts
+++ b/apps/api/src/subscriptions/dto/create-subscription.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SubscriptionStatus } from '@prisma/client';
+import { IsEnum, IsOptional, IsString, IsDateString } from 'class-validator';
+
+export class CreateSubscriptionDto {
+  @ApiProperty()
+  @IsString()
+  userId: string;
+
+  @ApiProperty()
+  @IsString()
+  planId: string;
+
+  @ApiProperty({ enum: SubscriptionStatus })
+  @IsEnum(SubscriptionStatus)
+  status: SubscriptionStatus;
+
+  @ApiProperty({ type: String })
+  @IsDateString()
+  currentPeriodEnd: string;
+}

--- a/apps/api/src/subscriptions/dto/update-subscription.dto.ts
+++ b/apps/api/src/subscriptions/dto/update-subscription.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateSubscriptionDto } from './create-subscription.dto';
+
+export class UpdateSubscriptionDto extends PartialType(CreateSubscriptionDto) {}

--- a/apps/api/src/subscriptions/subscriptions.controller.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { SubscriptionsService } from './subscriptions.service';
+import { CreateSubscriptionDto } from './dto/create-subscription.dto';
+import { UpdateSubscriptionDto } from './dto/update-subscription.dto';
+
+@ApiTags('subscriptions')
+@ApiBearerAuth()
+@Controller('subscriptions')
+export class SubscriptionsController {
+  constructor(private readonly service: SubscriptionsService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.service.get(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateSubscriptionDto) {
+    return this.service.create(dto);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateSubscriptionDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/apps/api/src/subscriptions/subscriptions.module.ts
+++ b/apps/api/src/subscriptions/subscriptions.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SubscriptionsService } from './subscriptions.service';
+import { SubscriptionsController } from './subscriptions.controller';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [SubscriptionsController],
+  providers: [SubscriptionsService],
+})
+export class SubscriptionsModule {}

--- a/apps/api/src/subscriptions/subscriptions.service.ts
+++ b/apps/api/src/subscriptions/subscriptions.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateSubscriptionDto } from './dto/create-subscription.dto';
+import { UpdateSubscriptionDto } from './dto/update-subscription.dto';
+
+@Injectable()
+export class SubscriptionsService {
+  constructor(private prisma: PrismaService) {}
+
+  list() {
+    return this.prisma.subscription.findMany();
+  }
+
+  get(id: string) {
+    return this.prisma.subscription.findUnique({ where: { id } });
+  }
+
+  create(dto: CreateSubscriptionDto) {
+    return this.prisma.subscription.create({
+      data: {
+        userId: dto.userId,
+        planId: dto.planId,
+        status: dto.status,
+        currentPeriodEnd: new Date(dto.currentPeriodEnd),
+      },
+    });
+  }
+
+  update(id: string, dto: UpdateSubscriptionDto) {
+    const data: any = { ...dto };
+    if (dto.currentPeriodEnd) {
+      data.currentPeriodEnd = new Date(dto.currentPeriodEnd);
+    }
+    return this.prisma.subscription.update({ where: { id }, data });
+  }
+
+  remove(id: string) {
+    return this.prisma.subscription.delete({ where: { id } });
+  }
+}

--- a/apps/api/src/users/dto/create-user.dto.ts
+++ b/apps/api/src/users/dto/create-user.dto.ts
@@ -5,7 +5,7 @@ import { IsEmail, IsOptional, IsString, IsBoolean, IsEnum } from 'class-validato
 export class CreateUserDto {
   @ApiProperty()
   @IsEmail()
-  email: string;
+  email!: string;
 
   @ApiProperty({ required: false })
   @IsOptional()

--- a/apps/api/src/users/dto/create-user.dto.ts
+++ b/apps/api/src/users/dto/create-user.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserRole } from '@prisma/client';
+import { IsEmail, IsOptional, IsString, IsBoolean, IsEnum } from 'class-validator';
+
+export class CreateUserDto {
+  @ApiProperty()
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  phone?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  passwordHash?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  passkeyPub?: string;
+
+  @ApiProperty({ required: false, default: false })
+  @IsOptional()
+  @IsBoolean()
+  twoFaEnabled?: boolean;
+
+  @ApiProperty({ required: false, enum: UserRole, default: UserRole.User })
+  @IsOptional()
+  @IsEnum(UserRole)
+  role?: UserRole;
+
+  @ApiProperty({ required: false, default: 'ru-RU' })
+  @IsOptional()
+  @IsString()
+  locale?: string;
+}

--- a/apps/api/src/users/dto/update-user.dto.ts
+++ b/apps/api/src/users/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateUserDto } from './create-user.dto';
+
+export class UpdateUserDto extends PartialType(CreateUserDto) {}

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { UsersService } from './users.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+
+@ApiTags('users')
+@ApiBearerAuth()
+@Controller('users')
+export class UsersController {
+  constructor(private readonly service: UsersService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.service.get(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateUserDto) {
+    return this.service.create(dto);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateUserDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [UsersController],
+  providers: [UsersService],
+})
+export class UsersModule {}

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+
+@Injectable()
+export class UsersService {
+  constructor(private prisma: PrismaService) {}
+
+  list() {
+    return this.prisma.user.findMany();
+  }
+
+  get(id: string) {
+    return this.prisma.user.findUnique({ where: { id } });
+  }
+
+  create(dto: CreateUserDto) {
+    return this.prisma.user.create({ data: dto });
+  }
+
+  update(id: string, dto: UpdateUserDto) {
+    return this.prisma.user.update({ where: { id }, data: dto });
+  }
+
+  remove(id: string) {
+    return this.prisma.user.delete({ where: { id } });
+  }
+}

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -268,3 +268,113 @@ paths:
       summary: Owner heartbeat ping
       responses:
         '204': { description: No Content }
+  /users:
+    get:
+      summary: List users
+      responses:
+        '200': { description: OK }
+    post:
+      summary: Create user
+      responses:
+        '201': { description: Created }
+  /users/{id}:
+    get:
+      summary: Get user
+      responses:
+        '200': { description: OK }
+    patch:
+      summary: Update user
+      responses:
+        '200': { description: OK }
+    delete:
+      summary: Delete user
+      responses:
+        '204': { description: No Content }
+  /plans:
+    get:
+      summary: List plans
+      responses:
+        '200': { description: OK }
+    post:
+      summary: Create plan
+      responses:
+        '201': { description: Created }
+  /plans/{id}:
+    get:
+      summary: Get plan
+      responses:
+        '200': { description: OK }
+    patch:
+      summary: Update plan
+      responses:
+        '200': { description: OK }
+    delete:
+      summary: Delete plan
+      responses:
+        '204': { description: No Content }
+  /subscriptions:
+    get:
+      summary: List subscriptions
+      responses:
+        '200': { description: OK }
+    post:
+      summary: Create subscription
+      responses:
+        '201': { description: Created }
+  /subscriptions/{id}:
+    get:
+      summary: Get subscription
+      responses:
+        '200': { description: OK }
+    patch:
+      summary: Update subscription
+      responses:
+        '200': { description: OK }
+    delete:
+      summary: Delete subscription
+      responses:
+        '204': { description: No Content }
+  /audit-logs:
+    get:
+      summary: List audit logs
+      responses:
+        '200': { description: OK }
+    post:
+      summary: Create audit log entry
+      responses:
+        '201': { description: Created }
+  /audit-logs/{id}:
+    get:
+      summary: Get audit log entry
+      responses:
+        '200': { description: OK }
+    patch:
+      summary: Update audit log entry
+      responses:
+        '200': { description: OK }
+    delete:
+      summary: Delete audit log entry
+      responses:
+        '204': { description: No Content }
+  /recovery-shares:
+    get:
+      summary: List recovery shares
+      responses:
+        '200': { description: OK }
+    post:
+      summary: Create recovery share
+      responses:
+        '201': { description: Created }
+  /recovery-shares/{id}:
+    get:
+      summary: Get recovery share
+      responses:
+        '200': { description: OK }
+    patch:
+      summary: Update recovery share
+      responses:
+        '200': { description: OK }
+    delete:
+      summary: Delete recovery share
+      responses:
+        '204': { description: No Content }


### PR DESCRIPTION
## Summary
- add CRUD modules for users, plans, subscriptions, audit logs and recovery shares
- register new modules and update OpenAPI spec

## Testing
- `cd apps/api && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2ad7e19048324922fcf15ee57cc32