### PR TITLE
feat(api): add audit logging for critical operations

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { PlansModule } from './plans/plans.module';
 import { SubscriptionsModule } from './subscriptions/subscriptions.module';
 import { AuditLogsModule } from './audit-logs/audit-logs.module';
 import { RecoverySharesModule } from './recovery-shares/recovery-shares.module';
+import { AuditModule } from './audit/audit.module';
 
 @Module({
 imports: [
@@ -36,6 +37,7 @@ imports: [
   SubscriptionsModule,
   AuditLogsModule,
   RecoverySharesModule,
+  AuditModule,
 ],
 })
 export class AppModule {}

--- a/apps/api/src/audit/audit.module.ts
+++ b/apps/api/src/audit/audit.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { AuditService } from './audit.service';
+
+@Global()
+@Module({
+  providers: [AuditService],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/apps/api/src/audit/audit.service.ts
+++ b/apps/api/src/audit/audit.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { ActorType } from '@prisma/client';
+
+@Injectable()
+export class AuditService {
+  // keep logs for one year by default
+  private readonly retentionMs = 365 * 24 * 3600 * 1000;
+
+  constructor(private prisma: PrismaService) {}
+
+  async log(
+    actorType: ActorType,
+    actorId: string,
+    action: string,
+    targetType?: string,
+    targetId?: string,
+    hash?: string,
+  ) {
+    await this.prisma.auditLog.create({
+      data: {
+        actorType,
+        actorId,
+        action,
+        targetType: targetType ?? null,
+        targetId: targetId ?? null,
+        hash: hash ?? null,
+      },
+    });
+
+    const cutoff = new Date(Date.now() - this.retentionMs);
+    await this.prisma.auditLog.deleteMany({ where: { ts: { lt: cutoff } } });
+  }
+}
+

--- a/apps/api/src/orchestrator/orchestrator.controller.ts
+++ b/apps/api/src/orchestrator/orchestrator.controller.ts
@@ -17,7 +17,7 @@ export class OrchestratorController {
   }
 
   @Post('decision')
-  decide(@CurrentUser() _user: any, @Body() dto: DecisionDto) {
-    return this.svc.decide(dto.vault_id, dto.verifier_id, dto.decision, dto.signature);
+  decide(@CurrentUser() user: any, @Body() dto: DecisionDto) {
+    return this.svc.decide(user.sub, dto.vault_id, dto.verifier_id, dto.decision, dto.signature);
   }
 }

--- a/apps/api/test/orchestrator.service.spec.ts
+++ b/apps/api/test/orchestrator.service.spec.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 describe('OrchestratorService transitions', () => {
   let prisma: any;
   let notify: any;
+  let audit: any;
   let service: OrchestratorService;
 
   beforeEach(() => {
@@ -19,7 +20,8 @@ describe('OrchestratorService transitions', () => {
       enqueueEmail: jest.fn(async () => {}),
       flushEmailQueue: jest.fn(async () => {}),
     } as any;
-    service = new OrchestratorService(prisma, notify);
+    audit = { log: jest.fn() };
+    service = new OrchestratorService(prisma, notify, audit);
   });
 
   it('transitions to Disputed when confirmations conflict', async () => {

--- a/apps/api/test/vaults.service.spec.ts
+++ b/apps/api/test/vaults.service.spec.ts
@@ -4,6 +4,7 @@ import { NotFoundException } from '@nestjs/common';
 
 describe('VaultsService', () => {
   let prisma: any;
+  let audit: any;
   let service: VaultsService;
 
   beforeEach(() => {
@@ -13,7 +14,8 @@ describe('VaultsService', () => {
         findFirst: jest.fn(),
       },
     } as any;
-    service = new VaultsService(prisma);
+    audit = { log: jest.fn() };
+    service = new VaultsService(prisma, audit);
   });
 
   it('creates vault with generated mk_wrapped', async () => {


### PR DESCRIPTION
## Summary
- add global audit service writing to `audit_log` with log retention
- record audit events in vaults, blocks, and orchestrator services
- adjust tests for new audit dependency

## Testing
- `cd apps/api && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2b18510c88324a0e605bba83dfd2a