### PR TITLE
chore: update seed user emails and admin password

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -62,20 +62,20 @@ async function main() {
   }
 
   await prisma.user.upsert({
-    where: { email: 'admin@example.com' },
+    where: { email: 'admin@afterl.ru' },
     update: {},
     create: {
-      email: 'admin@example.com',
-      passwordHash: await hashPassword('admin'),
+      email: 'admin@afterl.ru',
+      passwordHash: await hashPassword('S3cret!Admin2024'),
       role: 'Admin'
     }
   })
 
   await prisma.user.upsert({
-    where: { email: 'test1@example.com' },
+    where: { email: 'test1@afterl.ru' },
     update: {},
     create: {
-      email: 'test1@example.com',
+      email: 'test1@afterl.ru',
       passwordHash: await hashPassword('pass1'),
       role: 'User'
     }


### PR DESCRIPTION
## Summary
- update admin seed to use `admin@afterl.ru` with a strong password
- update test user email to `test1@afterl.ru`

## Testing
- `npx tsc -p tsconfig.build.json`
- `npx prisma db seed`
- `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68b2bbe5774c83249cb4e254b3d21d85