### PR TITLE
feat(auth): add credential-based login

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -5,6 +5,16 @@
       "post": {
         "operationId": "AuthController_login",
         "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginDto"
+              }
+            }
+          }
+        },
         "responses": {
           "201": {
             "description": ""
@@ -4485,6 +4495,21 @@
         "required": [
           "statusCode",
           "message"
+        ]
+      },
+      "LoginDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "password"
         ]
       },
       "CreateVaultDto": {

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -62,20 +62,20 @@ async function main() {
   }
 
   await prisma.user.upsert({
-    where: { email: 'admin@example.com' },
+    where: { email: 'admin@afterl.ru' },
     update: {},
     create: {
-      email: 'admin@example.com',
-      passwordHash: await hashPassword('admin'),
+      email: 'admin@afterl.ru',
+      passwordHash: await hashPassword('S3cret!Admin2024'),
       role: 'Admin'
     }
   })
 
   await prisma.user.upsert({
-    where: { email: 'test1@example.com' },
+    where: { email: 'test1@afterl.ru' },
     update: {},
     create: {
-      email: 'test1@example.com',
+      email: 'test1@afterl.ru',
       passwordHash: await hashPassword('pass1'),
       role: 'User'
     }

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UnauthorizedException } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { ApiErrorResponses } from '../common/api-error-responses.decorator';
+import { LoginDto } from './dto/login.dto';
 
 @ApiTags('auth')
 @ApiErrorResponses()
@@ -10,7 +11,11 @@ export class AuthController {
   constructor(private readonly auth: AuthService) {}
 
   @Post('login')
-  login(@Body('userId') userId: string) {
+  async login(@Body() { email, password }: LoginDto) {
+    const userId = await this.auth.validateUser(email, password);
+    if (!userId) {
+      throw new UnauthorizedException();
+    }
     return { access_token: this.auth.sign(userId) };
   }
 }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,12 +1,22 @@
 import { Injectable } from '@nestjs/common';
 import * as jwt from 'jsonwebtoken';
+import { PrismaService } from '../prisma/prisma.service';
+import { verifyPassword } from './password';
 
 @Injectable()
 export class AuthService {
   private readonly secret = process.env.JWT_SECRET || 'secret';
 
+  constructor(private readonly prisma: PrismaService) {}
+
   sign(userId: string): string {
     return jwt.sign({ sub: userId }, this.secret, { expiresIn: '1h' });
+  }
+
+  async validateUser(email: string, password: string): Promise<string | null> {
+    const user = await this.prisma.user.findUnique({ where: { email } });
+    if (!user || !user.passwordHash) return null;
+    return (await verifyPassword(password, user.passwordHash)) ? user.id : null;
   }
 
   verify(token: string): any {

--- a/apps/api/src/auth/dto/login.dto.ts
+++ b/apps/api/src/auth/dto/login.dto.ts
@@ -1,0 +1,12 @@
+import { IsEmail, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LoginDto {
+  @ApiProperty()
+  @IsEmail()
+  email!: string;
+
+  @ApiProperty()
+  @IsString()
+  password!: string;
+}

--- a/apps/api/src/auth/password.ts
+++ b/apps/api/src/auth/password.ts
@@ -1,0 +1,30 @@
+import { scryptAsync } from '@noble/hashes/scrypt';
+import { randomBytes, bytesToHex, hexToBytes } from '@noble/hashes/utils';
+
+function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+const params = { N: 16384, r: 8, p: 1, dkLen: 64 } as const;
+
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(16);
+  const key = await scryptAsync(new TextEncoder().encode(password), salt, params);
+  return `${bytesToHex(salt)}:${bytesToHex(key)}`;
+}
+
+export async function verifyPassword(password: string, stored: string): Promise<boolean> {
+  const [saltHex, hashHex] = stored.split(':');
+  if (!saltHex || !hashHex) return false;
+  const salt = hexToBytes(saltHex);
+  const hash = hexToBytes(hashHex);
+  try {
+    const derived = await scryptAsync(new TextEncoder().encode(password), salt, params);
+    return equalBytes(derived, hash);
+  } catch {
+    return false;
+  }
+}

--- a/apps/api/src/helmet.d.ts
+++ b/apps/api/src/helmet.d.ts
@@ -1,0 +1,1 @@
+declare module 'helmet';

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -3,2453 +3,4114 @@
  * Do not make direct changes to the file.
  */
 
-
 export interface paths {
-  "/auth/login": {
-    post: operations["AuthController_login"];
-  };
-  "/vaults": {
-    get: operations["VaultsController_list"];
-    post: operations["VaultsController_create"];
-  };
-  "/vaults/{id}": {
-    get: operations["VaultsController_get"];
-  };
-  "/vaults/{id}/settings": {
-    patch: operations["VaultsController_updateSettings"];
-  };
-  "/verifiers": {
-    get: operations["VerifiersController_list"];
-  };
-  "/verifiers/invitations": {
-    post: operations["VerifiersController_invite"];
-  };
-  "/verifiers/invitations/{vaultId}/{verifierId}/accept": {
-    post: operations["VerifiersController_accept"];
-  };
-  "/verification-events": {
-    get: operations["VerificationEventsController_list"];
-    post: operations["VerificationEventsController_start"];
-  };
-  "/verification-events/{id}": {
-    get: operations["VerificationEventsController_get"];
-  };
-  "/verification-events/{id}/confirm/{verifierId}": {
-    post: operations["VerificationEventsController_confirm"];
-  };
-  "/verification-events/{id}/deny/{verifierId}": {
-    post: operations["VerificationEventsController_deny"];
-  };
-  "/blocks": {
-    get: operations["BlocksController_list"];
-    post: operations["BlocksController_create"];
-  };
-  "/blocks/{id}": {
-    get: operations["BlocksController_get"];
-    delete: operations["BlocksController_remove"];
-  };
-  "/blocks/{id}/recipients": {
-    /** List recipients assigned to a block */
-    get: operations["BlocksController_listRecipients"];
-    /** Assign a recipient to a block */
-    post: operations["BlocksController_assignRecipient"];
-  };
-  "/recipients": {
-    get: operations["RecipientsController_search"];
-    post: operations["RecipientsController_create"];
-  };
-  "/blocks/{id}/public": {
-    get: operations["PublicLinksController_get"];
-    put: operations["PublicLinksController_upsert"];
-    delete: operations["PublicLinksController_disable"];
-  };
-  "/vaults/{vaultId}/heartbeat": {
-    get: operations["HeartbeatsController_getConfig"];
-    patch: operations["HeartbeatsController_updateConfig"];
-  };
-  "/heartbeats/ping": {
-    post: operations["HeartbeatsController_ping"];
-  };
-  "/orchestration/start": {
-    post: operations["OrchestratorController_start"];
-  };
-  "/orchestration/decision": {
-    post: operations["OrchestratorController_decide"];
-  };
-  "/healthz": {
-    get: operations["HealthController_healthz"];
-  };
-  "/readyz": {
-    get: operations["HealthController_readyz"];
-  };
-  "/users": {
-    get: operations["UsersController_list"];
-    post: operations["UsersController_create"];
-  };
-  "/users/{id}": {
-    get: operations["UsersController_get"];
-    delete: operations["UsersController_remove"];
-    patch: operations["UsersController_update"];
-  };
-  "/plans": {
-    get: operations["PlansController_list"];
-    post: operations["PlansController_create"];
-  };
-  "/plans/{id}": {
-    get: operations["PlansController_get"];
-    delete: operations["PlansController_remove"];
-    patch: operations["PlansController_update"];
-  };
-  "/subscriptions": {
-    get: operations["SubscriptionsController_list"];
-    post: operations["SubscriptionsController_create"];
-  };
-  "/subscriptions/{id}": {
-    get: operations["SubscriptionsController_get"];
-    delete: operations["SubscriptionsController_remove"];
-    patch: operations["SubscriptionsController_update"];
-  };
-  "/audit-logs": {
-    get: operations["AuditLogsController_list"];
-    post: operations["AuditLogsController_create"];
-  };
-  "/audit-logs/{id}": {
-    get: operations["AuditLogsController_get"];
-    delete: operations["AuditLogsController_remove"];
-    patch: operations["AuditLogsController_update"];
-  };
-  "/recovery-shares": {
-    get: operations["RecoverySharesController_list"];
-    post: operations["RecoverySharesController_create"];
-  };
-  "/recovery-shares/{id}": {
-    get: operations["RecoverySharesController_get"];
-    delete: operations["RecoverySharesController_remove"];
-    patch: operations["RecoverySharesController_update"];
-  };
+    "/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["AuthController_login"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/vaults": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["VaultsController_list"];
+        put?: never;
+        post: operations["VaultsController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/vaults/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["VaultsController_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/vaults/{id}/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["VaultsController_updateSettings"];
+        trace?: never;
+    };
+    "/verifiers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["VerifiersController_list"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/verifiers/invitations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["VerifiersController_invite"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/verifiers/invitations/{vaultId}/{verifierId}/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["VerifiersController_accept"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/verification-events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["VerificationEventsController_list"];
+        put?: never;
+        post: operations["VerificationEventsController_start"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/verification-events/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["VerificationEventsController_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/verification-events/{id}/confirm/{verifierId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["VerificationEventsController_confirm"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/verification-events/{id}/deny/{verifierId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["VerificationEventsController_deny"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/blocks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["BlocksController_list"];
+        put?: never;
+        post: operations["BlocksController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/blocks/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["BlocksController_get"];
+        put?: never;
+        post?: never;
+        delete: operations["BlocksController_remove"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/blocks/{id}/recipients": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List recipients assigned to a block */
+        get: operations["BlocksController_listRecipients"];
+        put?: never;
+        /** Assign a recipient to a block */
+        post: operations["BlocksController_assignRecipient"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/recipients": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["RecipientsController_search"];
+        put?: never;
+        post: operations["RecipientsController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/blocks/{id}/public": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["PublicLinksController_get"];
+        put: operations["PublicLinksController_upsert"];
+        post?: never;
+        delete: operations["PublicLinksController_disable"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/vaults/{vaultId}/heartbeat": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["HeartbeatsController_getConfig"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["HeartbeatsController_updateConfig"];
+        trace?: never;
+    };
+    "/heartbeats/ping": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["HeartbeatsController_ping"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/orchestration/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["OrchestratorController_start"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/orchestration/decision": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["OrchestratorController_decide"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/healthz": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["HealthController_healthz"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/readyz": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["HealthController_readyz"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["UsersController_list"];
+        put?: never;
+        post: operations["UsersController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["UsersController_get"];
+        put?: never;
+        post?: never;
+        delete: operations["UsersController_remove"];
+        options?: never;
+        head?: never;
+        patch: operations["UsersController_update"];
+        trace?: never;
+    };
+    "/plans": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["PlansController_list"];
+        put?: never;
+        post: operations["PlansController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/plans/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["PlansController_get"];
+        put?: never;
+        post?: never;
+        delete: operations["PlansController_remove"];
+        options?: never;
+        head?: never;
+        patch: operations["PlansController_update"];
+        trace?: never;
+    };
+    "/subscriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["SubscriptionsController_list"];
+        put?: never;
+        post: operations["SubscriptionsController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/subscriptions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["SubscriptionsController_get"];
+        put?: never;
+        post?: never;
+        delete: operations["SubscriptionsController_remove"];
+        options?: never;
+        head?: never;
+        patch: operations["SubscriptionsController_update"];
+        trace?: never;
+    };
+    "/audit-logs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["AuditLogsController_list"];
+        put?: never;
+        post: operations["AuditLogsController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/audit-logs/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["AuditLogsController_get"];
+        put?: never;
+        post?: never;
+        delete: operations["AuditLogsController_remove"];
+        options?: never;
+        head?: never;
+        patch: operations["AuditLogsController_update"];
+        trace?: never;
+    };
+    "/recovery-shares": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["RecoverySharesController_list"];
+        put?: never;
+        post: operations["RecoverySharesController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/recovery-shares/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["RecoverySharesController_get"];
+        put?: never;
+        post?: never;
+        delete: operations["RecoverySharesController_remove"];
+        options?: never;
+        head?: never;
+        patch: operations["RecoverySharesController_update"];
+        trace?: never;
+    };
 }
-
 export type webhooks = Record<string, never>;
-
 export interface components {
-  schemas: {
-    ErrorDto: {
-      /** @example 400 */
-      statusCode: number;
-      /** @example Bad Request */
-      message: string;
-      /** @example Validation failed */
-      error?: string;
+    schemas: {
+        ErrorDto: {
+            /** @example 400 */
+            statusCode: number;
+            /** @example Bad Request */
+            message: string;
+            /** @example Validation failed */
+            error?: string;
+        };
+        LoginDto: {
+            email: string;
+            password: string;
+        };
+        CreateVaultDto: {
+            /** @default false */
+            is_demo: boolean;
+            /** @default 3 */
+            quorum_threshold: number;
+            /** @default 5 */
+            max_verifiers: number;
+            /** @default 60 */
+            heartbeat_timeout_days: number;
+            /** @default 24 */
+            grace_hours: number;
+        };
+        UpdateVaultSettingsDto: {
+            quorum_threshold?: number;
+            max_verifiers?: number;
+            heartbeat_timeout_days?: number;
+            grace_hours?: number;
+            /** @description Optional primary verifier id */
+            primary_verifier_id?: string;
+        };
+        InviteVerifierDto: {
+            vault_id: string;
+            /** @description email for MVP */
+            contact: string;
+            /**
+             * @description expires in hours (default 7 days)
+             * @default 168
+             */
+            expires_in_hours: number;
+        };
+        StartVerificationEventDto: {
+            vault_id: string;
+        };
+        DecisionDto: {
+            /** Format: uuid */
+            vault_id: string;
+            /**
+             * Format: uuid
+             * @description ID верификатора (MVP: из тела запроса)
+             */
+            verifier_id: string;
+            /** @enum {string} */
+            decision: "Confirm" | "Deny";
+            signature?: string;
+        };
+        CreateBlockDto: {
+            /** Format: uuid */
+            vault_id: string;
+            /** @enum {string} */
+            type: "text" | "file" | "url";
+            /** @description Wrapped DEK (base64 or JWE compact) */
+            dek_wrapped: string;
+            /** @description Arbitrary JSON metadata (stringified or object) */
+            metadata?: Record<string, never>;
+            /** @default [] */
+            tags: string[];
+            /** @description Encrypted payload size in bytes */
+            size?: number;
+            checksum?: string;
+            /** @default false */
+            is_public: boolean;
+        };
+        AssignRecipientDto: {
+            /** Format: uuid */
+            recipient_id: string;
+            /** @description DEK wrapped for this recipient (base64 or JWE compact) */
+            dek_wrapped_for_recipient: string;
+        };
+        CreateRecipientDto: {
+            /** @description Email получателя (уникальный идентификатор) */
+            contact: string;
+            /** @description Публичный ключ получателя (если уже есть) */
+            pubkey?: string;
+        };
+        UpdatePublicLinkDto: {
+            enabled: boolean;
+            publish_from?: string;
+            publish_until?: Record<string, never>;
+            max_views?: Record<string, never> | null;
+        };
+        UpdateHeartbeatDto: {
+            /** @enum {string} */
+            method?: "auto" | "manual";
+            /** @description Таймаут неактивности в днях */
+            timeout_days?: number;
+        };
+        HeartbeatPingDto: {
+            /** Format: uuid */
+            vault_id: string;
+            /** @enum {string} */
+            method?: "auto" | "manual";
+        };
+        StartEventDto: {
+            /** Format: uuid */
+            vault_id: string;
+        };
+        UserDto: {
+            id: string;
+            email: string;
+            phone?: string;
+            twoFaEnabled: boolean;
+            /** @enum {string} */
+            role: "User" | "Admin";
+            locale: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        CreateUserDto: {
+            email: string;
+            phone?: string;
+            passwordHash?: string;
+            passkeyPub?: string;
+            /** @default false */
+            twoFaEnabled: boolean;
+            /**
+             * @default User
+             * @enum {string}
+             */
+            role: "User" | "Admin";
+            /** @default ru-RU */
+            locale: string;
+        };
+        UpdateUserDto: {
+            email?: string;
+            phone?: string;
+            passwordHash?: string;
+            passkeyPub?: string;
+            /** @default false */
+            twoFaEnabled: boolean;
+            /**
+             * @default User
+             * @enum {string}
+             */
+            role: "User" | "Admin";
+            /** @default ru-RU */
+            locale: string;
+        };
+        CreatePlanDto: {
+            /** @enum {string} */
+            tier: "Free" | "Pro" | "Business";
+            limits: Record<string, never>;
+        };
+        UpdatePlanDto: {
+            /** @enum {string} */
+            tier?: "Free" | "Pro" | "Business";
+            limits?: Record<string, never>;
+        };
+        CreateSubscriptionDto: {
+            userId: string;
+            planId: string;
+            /** @enum {string} */
+            status: "trial" | "active" | "canceled";
+            currentPeriodEnd: string;
+        };
+        UpdateSubscriptionDto: {
+            userId?: string;
+            planId?: string;
+            /** @enum {string} */
+            status?: "trial" | "active" | "canceled";
+            currentPeriodEnd?: string;
+        };
+        CreateAuditLogDto: {
+            /** @enum {string} */
+            actorType: "User" | "Verifier" | "System";
+            actorId: string;
+            action: string;
+            targetId?: string;
+            targetType?: string;
+            hash?: string;
+        };
+        UpdateAuditLogDto: {
+            /** @enum {string} */
+            actorType?: "User" | "Verifier" | "System";
+            actorId?: string;
+            action?: string;
+            targetId?: string;
+            targetType?: string;
+            hash?: string;
+        };
+        CreateRecoveryShareDto: {
+            vaultId: string;
+            shareIndex: number;
+            shareCipher: string;
+        };
+        UpdateRecoveryShareDto: {
+            vaultId?: string;
+            shareIndex?: number;
+            shareCipher?: string;
+        };
     };
-    CreateVaultDto: {
-      /** @default false */
-      is_demo?: boolean;
-      /** @default 3 */
-      quorum_threshold?: number;
-      /** @default 5 */
-      max_verifiers?: number;
-      /** @default 60 */
-      heartbeat_timeout_days?: number;
-      /** @default 24 */
-      grace_hours?: number;
-    };
-    UpdateVaultSettingsDto: {
-      quorum_threshold?: number;
-      max_verifiers?: number;
-      heartbeat_timeout_days?: number;
-      grace_hours?: number;
-      /** @description Optional primary verifier id */
-      primary_verifier_id?: string;
-    };
-    InviteVerifierDto: {
-      vault_id: string;
-      /** @description email for MVP */
-      contact: string;
-      /**
-       * @description expires in hours (default 7 days)
-       * @default 168
-       */
-      expires_in_hours?: number;
-    };
-    StartVerificationEventDto: {
-      vault_id: string;
-    };
-    DecisionDto: {
-      /** Format: uuid */
-      vault_id: string;
-      /**
-       * Format: uuid
-       * @description ID верификатора (MVP: из тела запроса)
-       */
-      verifier_id: string;
-      /** @enum {string} */
-      decision: "Confirm" | "Deny";
-      signature?: string;
-    };
-    CreateBlockDto: {
-      /** Format: uuid */
-      vault_id: string;
-      /** @enum {string} */
-      type: "text" | "file" | "url";
-      /** @description Wrapped DEK (base64 or JWE compact) */
-      dek_wrapped: string;
-      /** @description Arbitrary JSON metadata (stringified or object) */
-      metadata?: Record<string, never>;
-      /** @default [] */
-      tags?: string[];
-      /** @description Encrypted payload size in bytes */
-      size?: number;
-      checksum?: string;
-      /** @default false */
-      is_public?: boolean;
-    };
-    AssignRecipientDto: {
-      /** Format: uuid */
-      recipient_id: string;
-      /** @description DEK wrapped for this recipient (base64 or JWE compact) */
-      dek_wrapped_for_recipient: string;
-    };
-    CreateRecipientDto: {
-      /** @description Email получателя (уникальный идентификатор) */
-      contact: string;
-      /** @description Публичный ключ получателя (если уже есть) */
-      pubkey?: string;
-    };
-    UpdatePublicLinkDto: {
-      enabled: boolean;
-      publish_from?: string;
-      publish_until?: Record<string, never>;
-      max_views?: Record<string, unknown> | null;
-    };
-    UpdateHeartbeatDto: {
-      /** @enum {string} */
-      method?: "auto" | "manual";
-      /** @description Таймаут неактивности в днях */
-      timeout_days?: number;
-    };
-    HeartbeatPingDto: {
-      /** Format: uuid */
-      vault_id: string;
-      /** @enum {string} */
-      method?: "auto" | "manual";
-    };
-    StartEventDto: {
-      /** Format: uuid */
-      vault_id: string;
-    };
-    UserDto: {
-      id: string;
-      email: string;
-      phone?: string;
-      twoFaEnabled: boolean;
-      /** @enum {string} */
-      role: "User" | "Admin";
-      locale: string;
-      /** Format: date-time */
-      createdAt: string;
-      /** Format: date-time */
-      updatedAt: string;
-    };
-    CreateUserDto: {
-      email: string;
-      phone?: string;
-      passwordHash?: string;
-      passkeyPub?: string;
-      /** @default false */
-      twoFaEnabled?: boolean;
-      /**
-       * @default User
-       * @enum {string}
-       */
-      role?: "User" | "Admin";
-      /** @default ru-RU */
-      locale?: string;
-    };
-    UpdateUserDto: {
-      email?: string;
-      phone?: string;
-      passwordHash?: string;
-      passkeyPub?: string;
-      /** @default false */
-      twoFaEnabled?: boolean;
-      /**
-       * @default User
-       * @enum {string}
-       */
-      role?: "User" | "Admin";
-      /** @default ru-RU */
-      locale?: string;
-    };
-    CreatePlanDto: {
-      /** @enum {string} */
-      tier: "Free" | "Pro" | "Business";
-      limits: Record<string, never>;
-    };
-    UpdatePlanDto: {
-      /** @enum {string} */
-      tier?: "Free" | "Pro" | "Business";
-      limits?: Record<string, never>;
-    };
-    CreateSubscriptionDto: {
-      userId: string;
-      planId: string;
-      /** @enum {string} */
-      status: "trial" | "active" | "canceled";
-      currentPeriodEnd: string;
-    };
-    UpdateSubscriptionDto: {
-      userId?: string;
-      planId?: string;
-      /** @enum {string} */
-      status?: "trial" | "active" | "canceled";
-      currentPeriodEnd?: string;
-    };
-    CreateAuditLogDto: {
-      /** @enum {string} */
-      actorType: "User" | "Verifier" | "System";
-      actorId: string;
-      action: string;
-      targetId?: string;
-      targetType?: string;
-      hash?: string;
-    };
-    UpdateAuditLogDto: {
-      /** @enum {string} */
-      actorType?: "User" | "Verifier" | "System";
-      actorId?: string;
-      action?: string;
-      targetId?: string;
-      targetType?: string;
-      hash?: string;
-    };
-    CreateRecoveryShareDto: {
-      vaultId: string;
-      shareIndex: number;
-      shareCipher: string;
-    };
-    UpdateRecoveryShareDto: {
-      vaultId?: string;
-      shareIndex?: number;
-      shareCipher?: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
-
 export type $defs = Record<string, never>;
-
-export type external = Record<string, never>;
-
 export interface operations {
-
-  AuthController_login: {
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  VaultsController_list: {
-    parameters: {
-      query: {
-        cursor: string;
-        limit: number;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  VaultsController_create: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateVaultDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  VaultsController_get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  VaultsController_updateSettings: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateVaultSettingsDto"];
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  VerifiersController_list: {
-    parameters: {
-      query: {
-        vault_id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  VerifiersController_invite: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["InviteVerifierDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  VerifiersController_accept: {
-    parameters: {
-      path: {
-        vaultId: string;
-        verifierId: string;
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  VerificationEventsController_list: {
-    parameters: {
-      query: {
-        vault_id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  VerificationEventsController_start: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["StartVerificationEventDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  VerificationEventsController_get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  VerificationEventsController_confirm: {
-    parameters: {
-      path: {
-        id: string;
-        verifierId: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["DecisionDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  VerificationEventsController_deny: {
-    parameters: {
-      path: {
-        id: string;
-        verifierId: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["DecisionDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  BlocksController_list: {
-    parameters: {
-      query: {
-        vault_id: string;
-        cursor: string;
-        limit: number;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  BlocksController_create: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateBlockDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  BlocksController_get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  BlocksController_remove: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  /** List recipients assigned to a block */
-  BlocksController_listRecipients: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  /** Assign a recipient to a block */
-  BlocksController_assignRecipient: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AssignRecipientDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  RecipientsController_search: {
-    parameters: {
-      query?: {
-        /** @description Подстрока для поиска по contact */
-        q?: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  RecipientsController_create: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateRecipientDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  PublicLinksController_get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  PublicLinksController_upsert: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdatePublicLinkDto"];
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  PublicLinksController_disable: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  HeartbeatsController_getConfig: {
-    parameters: {
-      path: {
-        vaultId: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  HeartbeatsController_updateConfig: {
-    parameters: {
-      path: {
-        vaultId: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateHeartbeatDto"];
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  HeartbeatsController_ping: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["HeartbeatPingDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  OrchestratorController_start: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["StartEventDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  OrchestratorController_decide: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["DecisionDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  HealthController_healthz: {
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  HealthController_readyz: {
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  UsersController_list: {
-    responses: {
-      200: {
-        content: {
-          "application/json": components["schemas"]["UserDto"][];
-        };
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  UsersController_create: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateUserDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: {
-          "application/json": components["schemas"]["UserDto"];
-        };
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  UsersController_get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: {
-          "application/json": components["schemas"]["UserDto"];
-        };
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  UsersController_remove: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: {
-          "application/json": components["schemas"]["UserDto"];
-        };
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  UsersController_update: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateUserDto"];
-      };
-    };
-    responses: {
-      200: {
-        content: {
-          "application/json": components["schemas"]["UserDto"];
-        };
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  PlansController_list: {
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  PlansController_create: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreatePlanDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  PlansController_get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  PlansController_remove: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  PlansController_update: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdatePlanDto"];
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  SubscriptionsController_list: {
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  SubscriptionsController_create: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateSubscriptionDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  SubscriptionsController_get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  SubscriptionsController_remove: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  SubscriptionsController_update: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateSubscriptionDto"];
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  AuditLogsController_list: {
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  AuditLogsController_create: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateAuditLogDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  AuditLogsController_get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  AuditLogsController_remove: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  AuditLogsController_update: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateAuditLogDto"];
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  RecoverySharesController_list: {
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  RecoverySharesController_create: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateRecoveryShareDto"];
-      };
-    };
-    responses: {
-      201: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  RecoverySharesController_get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  RecoverySharesController_remove: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-    };
-  };
-  RecoverySharesController_update: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateRecoveryShareDto"];
-      };
-    };
-    responses: {
-      200: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
-      500: {
-        content: {
-          "application/json": components["schemas"]["ErrorDto"];
-        };
-      };
+    AuthController_login: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LoginDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    VaultsController_list: {
+        parameters: {
+            query: {
+                cursor: string;
+                limit: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    VaultsController_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateVaultDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    VaultsController_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    VaultsController_updateSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateVaultSettingsDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    VerifiersController_list: {
+        parameters: {
+            query: {
+                vault_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    VerifiersController_invite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InviteVerifierDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    VerifiersController_accept: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                vaultId: string;
+                verifierId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    VerificationEventsController_list: {
+        parameters: {
+            query: {
+                vault_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    VerificationEventsController_start: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StartVerificationEventDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    VerificationEventsController_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    VerificationEventsController_confirm: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                verifierId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DecisionDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    VerificationEventsController_deny: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                verifierId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DecisionDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    BlocksController_list: {
+        parameters: {
+            query: {
+                vault_id: string;
+                cursor: string;
+                limit: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    BlocksController_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateBlockDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    BlocksController_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    BlocksController_remove: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    BlocksController_listRecipients: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    BlocksController_assignRecipient: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AssignRecipientDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    RecipientsController_search: {
+        parameters: {
+            query?: {
+                /** @description Подстрока для поиска по contact */
+                q?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    RecipientsController_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateRecipientDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    PublicLinksController_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    PublicLinksController_upsert: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdatePublicLinkDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    PublicLinksController_disable: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    HeartbeatsController_getConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                vaultId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    HeartbeatsController_updateConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                vaultId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateHeartbeatDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    HeartbeatsController_ping: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["HeartbeatPingDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    OrchestratorController_start: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StartEventDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    OrchestratorController_decide: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DecisionDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    HealthController_healthz: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    HealthController_readyz: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    UsersController_list: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserDto"][];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    UsersController_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateUserDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserDto"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    UsersController_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserDto"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    UsersController_remove: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserDto"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    UsersController_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateUserDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserDto"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    PlansController_list: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    PlansController_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreatePlanDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    PlansController_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    PlansController_remove: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    PlansController_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdatePlanDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    SubscriptionsController_list: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    SubscriptionsController_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateSubscriptionDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    SubscriptionsController_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    SubscriptionsController_remove: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    SubscriptionsController_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateSubscriptionDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    AuditLogsController_list: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    AuditLogsController_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateAuditLogDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    AuditLogsController_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    AuditLogsController_remove: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    AuditLogsController_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateAuditLogDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    RecoverySharesController_list: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    RecoverySharesController_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateRecoveryShareDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    RecoverySharesController_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    RecoverySharesController_remove: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
+    };
+    RecoverySharesController_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateRecoveryShareDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDto"];
+                };
+            };
+        };
     };
-  };
 }


### PR DESCRIPTION
## Summary
- allow authentication using email and password with hashed verification
- document login request body in OpenAPI and regenerate web API client

## Testing
- `npx tsc -p tsconfig.build.json`
- `npx prisma db seed` *(fails: Environment variable not found: DATABASE_URL)*
- `npm test`
- `npm run openapi` *(fails: Cannot read properties of undefined (reading 'findMany'))*

------
https://chatgpt.com/codex/tasks/task_e_68b2bbe5774c83249cb4e254b3d21d85