### PR TITLE
feat: add dev layout

### DIFF
--- a/apps/web/src/app/dev/layout.tsx
+++ b/apps/web/src/app/dev/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+
+export default function DevLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header />
+      <main className="flex-1">{children}</main>
+      <footer />
+    </div>
+  );
+}

--- a/apps/web/src/app/dev/page.tsx
+++ b/apps/web/src/app/dev/page.tsx
@@ -1,0 +1,3 @@
+export default function DevHome() {
+  return <div>/dev home</div>;
+}

--- a/apps/web/src/lib/landing.ts
+++ b/apps/web/src/lib/landing.ts
@@ -20,16 +20,17 @@ const defaultConfig: LandingConfig = {
   title: 'Afterlight',
   subtitle: 'Идёт разработка с\u00a0помощью искусственного интеллекта',
   description: 'Скоро здесь появится серьёзный проект.',
-  bgColor: '#000000',
-  titleColor: '#10a37f',
-  subtitleColor: '#ffffff',
-  descriptionColor: '#ffffff',
-  links: {
-    telegram: 'https://t.me/retrotink',
-    github: 'https://github.com/retrotink/afterlight',
-    dev: '/dev',
-  },
-};
+    bgColor: '#000000',
+    titleColor: '#10a37f',
+    subtitleColor: '#ffffff',
+    descriptionColor: '#ffffff',
+    links: {
+      telegram: 'https://t.me/retrotink',
+      github: 'https://github.com/retrotink/afterlight',
+      // route for development layout
+      dev: '/dev',
+    },
+  };
 
 export function getLandingConfig(): LandingConfig {
   return {


### PR DESCRIPTION
## Summary
- add dedicated `/dev` layout with header/footer placeholders
- stub `/dev` page
- document `/dev` link in landing config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: unknown option '--no-error-on-unmatched-pattern')*

------
https://chatgpt.com/codex/tasks/task_e_68b2eb4810588324b4c7fa433a182b0e