### PR TITLE
feat(web): add http client wrapper

### DIFF
--- a/apps/web/src/components/footer-links.tsx
+++ b/apps/web/src/components/footer-links.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, FormEvent } from 'react';
+import { httpClient } from '../shared/api/httpClient';
 import {
   FaTelegramPlane,
   FaGithub,
@@ -28,7 +29,7 @@ export default function FooterLinks({ links }: { links: Links }) {
     setError('');
     const encoded = btoa(`${email}:${password}`);
     try {
-      const res = await fetch('/api/landing', {
+      const res = await httpClient('/landing', {
         method: 'HEAD',
         headers: { Authorization: `Basic ${encoded}` },
       });

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { httpClient } from './shared/api/httpClient';
 // Prisma cannot run in Edge middleware; use API route instead
 
 function unauthorized() {
@@ -14,10 +15,11 @@ export async function middleware(req: NextRequest) {
   const auth = `Basic ${authCookie.value}`;
 
   try {
-    const res = await fetch(new URL('/api/landing', req.url), {
+    const res = await httpClient('/landing', {
       headers: { authorization: auth },
       // ensure fresh auth check
       cache: 'no-store',
+      base: req.url,
     });
     if (res.status !== 200) return unauthorized();
   } catch {

--- a/apps/web/src/shared/api/httpClient.ts
+++ b/apps/web/src/shared/api/httpClient.ts
@@ -1,0 +1,22 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || '/api';
+
+interface HttpClientOptions extends RequestInit {
+  base?: string;
+}
+
+export async function httpClient(
+  path: string,
+  { base, ...init }: HttpClientOptions = {}
+) {
+  const basePath = API_BASE.endsWith('/') ? API_BASE.slice(0, -1) : API_BASE;
+  const finalPath = path.startsWith('/') ? path : `/${path}`;
+  const url = base
+    ? new URL(`${basePath}${finalPath}`, base).toString()
+    : `${basePath}${finalPath}`;
+  try {
+    return await fetch(url, { ...init, credentials: 'include' });
+  } catch (error) {
+    console.error('HTTP request failed', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared HTTP client with base URL and credential defaults
- use new client in footer login and middleware checks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: unknown option '--no-error-on-unmatched-pattern')*

------
https://chatgpt.com/codex/tasks/task_e_68b2eb55dc70832489c530066377bffd