### PR TITLE
feat: add verifier event actions

### DIFF
--- a/apps/web/src/app/dev/verifier/page.tsx
+++ b/apps/web/src/app/dev/verifier/page.tsx
@@ -1,8 +1,82 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface VerificationEvent {
+  id: string;
+  state: string;
+  confirmations?: number;
+  denials?: number;
+  confirmsCount?: number;
+  deniesCount?: number;
+}
+
 export default function VerifierPage() {
+  const [events, setEvents] = useState<VerificationEvent[]>([]);
+
+  useEffect(() => {
+    fetch('/verification-events')
+      .then(res => res.json())
+      .then(setEvents)
+      .catch(() => {});
+  }, []);
+
+  const updateEvent = (evt: VerificationEvent) => {
+    setEvents(prev => prev.map(e => (e.id === evt.id ? evt : e)));
+  };
+
+  const handleAction = async (id: string, action: 'confirm' | 'deny') => {
+    const res = await fetch(`/verification-events/${id}/${action}`, {
+      method: 'POST',
+    });
+
+    if (res.status === 403 || res.status === 404) {
+      alert(res.status === 403 ? 'Доступ запрещён' : 'Событие не найдено');
+      return;
+    }
+
+    const data = await res.json();
+    updateEvent(data);
+  };
+
+  const renderCounters = (e: VerificationEvent) => {
+    const confirms = e.confirmsCount ?? e.confirmations ?? 0;
+    const denies = e.deniesCount ?? e.denials ?? 0;
+    return (
+      <div className="text-sm text-gray-600">
+        Подтверждения: {confirms} / Отказы: {denies}
+      </div>
+    );
+  };
+
   return (
-    <div className="p-6">
+    <div className="p-6 space-y-4">
       <h1 className="text-2xl font-bold">Кабинет верификатора</h1>
-      <p>Заглушка кабинета верификатора.</p>
+      <p className="text-sm text-gray-600">
+        Требуется 2 подтверждения из 3. Публичная ссылка активна 24 часа.
+      </p>
+      {events.map(e => (
+        <div key={e.id} className="border rounded p-4 space-y-2">
+          <div className="font-mono text-sm">ID: {e.id}</div>
+          <div>Состояние: {e.state}</div>
+          {renderCounters(e)}
+          <div className="space-x-2">
+            <button
+              onClick={() => handleAction(e.id, 'confirm')}
+              className="bg-green-500 text-white px-2 py-1 rounded"
+            >
+              Подтвердить
+            </button>
+            <button
+              onClick={() => handleAction(e.id, 'deny')}
+              className="bg-red-500 text-white px-2 py-1 rounded"
+            >
+              Отклонить
+            </button>
+          </div>
+        </div>
+      ))}
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- load verification events and show cards in verifier dashboard
- allow confirming or denying events and update state locally
- show quorum and 24h timer hint

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f68788e083248f2132632e2cd70d