### PR TITLE
feat(dev): add how-to, policies and contacts pages

### DIFF
--- a/apps/web/src/app/dev/contacts/page.tsx
+++ b/apps/web/src/app/dev/contacts/page.tsx
@@ -1,8 +1,14 @@
 export default function ContactsPage() {
   return (
-    <div className="p-6">
+    <div className="p-6 space-y-4">
       <h1 className="text-2xl font-bold">Контакты</h1>
-      <p>Заглушка страницы контактов.</p>
+      <p>
+        По вопросам поддержки пишите на{' '}
+        <a className="text-blue-600 underline" href="mailto:support@afterl.ru">
+          support@afterl.ru
+        </a>
+        .
+      </p>
     </div>
   );
 }

--- a/apps/web/src/app/dev/how/page.tsx
+++ b/apps/web/src/app/dev/how/page.tsx
@@ -1,8 +1,43 @@
 export default function HowPage() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">Как это работает</h1>
-      <p>Заглушка страницы о том, как это работает.</p>
+    <div className="p-6 space-y-8">
+      <section>
+        <h1 className="text-2xl font-bold mb-4">Как это работает</h1>
+        <ol className="list-decimal space-y-2 pl-6">
+          <li>Создайте сейф и добавьте 3 верификаторов.</li>
+          <li>Настройте блоки и получателей.</li>
+          <li>
+            При наступлении события два подтверждения запускают раскрытие. Через 24
+            часа доступ будет открыт.
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-4">FAQ</h2>
+        <div className="space-y-4">
+          <div>
+            <h3 className="font-medium">Как обеспечивается безопасность?</h3>
+            <p>
+              Содержимое шифруется на вашем устройстве. Мы храним только
+              зашифрованные данные и технические метаданные.
+            </p>
+          </div>
+          <div>
+            <h3 className="font-medium">Как подтверждается событие?</h3>
+            <p>
+              Двое из трёх доверенных людей подтверждают событие. После этого
+              запускается раскрытие сейфа.
+            </p>
+          </div>
+          <div>
+            <h3 className="font-medium">Есть ли контроль времени?</h3>
+            <p>
+              У вас сутки на финальные действия, а окно «я на связи» длится год.
+            </p>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/web/src/app/dev/policies/page.tsx
+++ b/apps/web/src/app/dev/policies/page.tsx
@@ -1,8 +1,87 @@
+import fs from 'fs';
+import path from 'path';
+import React from 'react';
+
+function renderMarkdown(md: string) {
+  const lines = md.split('\n');
+  const elements: React.ReactNode[] = [];
+  let list: React.ReactNode[] | null = null;
+
+  lines.forEach((line, idx) => {
+    if (line.startsWith('# ')) {
+      if (list) {
+        elements.push(<ul key={`ul-${idx}`}>{list}</ul>);
+        list = null;
+      }
+      elements.push(
+        <h2 key={`h1-${idx}`} className="text-xl font-semibold">
+          {line.replace('# ', '')}
+        </h2>
+      );
+    } else if (/^\d+\.\s/.test(line)) {
+      if (list) {
+        elements.push(<ul key={`ul-${idx}`}>{list}</ul>);
+        list = null;
+      }
+      const id = line.match(/^\d+/)?.[0] || `${idx}`;
+      elements.push(
+        <h3 key={`h2-${idx}`} id={`section-${id}`} className="mt-4 font-medium">
+          {line}
+        </h3>
+      );
+    } else if (line.startsWith('- ')) {
+      list = list || [];
+      list.push(<li key={`li-${idx}`}>{line.replace('- ', '')}</li>);
+    } else if (line.trim() === '') {
+      if (list) {
+        elements.push(<ul key={`ul-${idx}`}>{list}</ul>);
+        list = null;
+      } else {
+        elements.push(<p key={`p-${idx}`} className="mt-2"></p>);
+      }
+    } else {
+      if (list) {
+        elements.push(<ul key={`ul-${idx}`}>{list}</ul>);
+        list = null;
+      }
+      elements.push(<p key={`p-${idx}`}>{line}</p>);
+    }
+  });
+
+  if (list) {
+    elements.push(<ul key="ul-end">{list}</ul>);
+  }
+
+  return elements;
+}
+
 export default function PoliciesPage() {
+  const base = path.join(process.cwd(), 'docs/policies');
+  const terms = fs.readFileSync(path.join(base, 'Terms-draft-RU.md'), 'utf-8');
+  const privacy = fs.readFileSync(
+    path.join(base, 'PrivacyPolicy-draft-RU.md'),
+    'utf-8'
+  );
+
   return (
-    <div className="p-6">
+    <div className="p-6 space-y-8">
       <h1 className="text-2xl font-bold">Политики</h1>
-      <p>Заглушка страницы политик.</p>
+      <nav className="my-4">
+        <ul className="list-disc pl-6 space-y-1">
+          <li>
+            <a href="#terms">Пользовательское соглашение</a>
+          </li>
+          <li>
+            <a href="#privacy">Политика конфиденциальности</a>
+          </li>
+        </ul>
+      </nav>
+      <section id="terms" className="space-y-2">
+        {renderMarkdown(terms)}
+      </section>
+      <section id="privacy" className="space-y-2">
+        {renderMarkdown(privacy)}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- flesh out dev how-to page with steps and FAQ
- render policy drafts with anchors on dev policies page
- show support email placeholder on dev contacts page

## Testing
- `npm run lint` *(fails: prompted for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f68242b883249ac25e2cdb3a57d0