### PR TITLE
Fix policies doc lookup path

### DIFF
--- a/apps/web/src/app/dev/policies/page.tsx
+++ b/apps/web/src/app/dev/policies/page.tsx
@@ -56,7 +56,8 @@ function renderMarkdown(md: string) {
 }
 
 export default function PoliciesPage() {
-  const base = path.join(process.cwd(), 'docs/policies');
+  // Resolve docs directory from repository root instead of app root
+  const base = path.resolve(process.cwd(), '..', '..', 'docs', 'policies');
   const terms = fs.readFileSync(path.join(base, 'Terms-draft-RU.md'), 'utf-8');
   const privacy = fs.readFileSync(
     path.join(base, 'PrivacyPolicy-draft-RU.md'),


### PR DESCRIPTION
## Summary
- fix policies page doc path to point at root `docs/policies`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint config)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2ea834e988324a354a165e78c8fd2