### PR TITLE
Implement cookie-based auth with admin basic access

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,8 +1,19 @@
-import { Body, Controller, Post, UnauthorizedException } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  UnauthorizedException,
+  Res,
+  Get,
+  Req,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { ApiErrorResponses } from '../common/api-error-responses.decorator';
 import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
+import { Response, Request } from 'express';
+import { UserRole } from '@prisma/client';
 
 @ApiTags('auth')
 @ApiErrorResponses()
@@ -10,12 +21,45 @@ import { LoginDto } from './dto/login.dto';
 export class AuthController {
   constructor(private readonly auth: AuthService) {}
 
+  @Post('register')
+  async register(@Body() dto: RegisterDto) {
+    const user = await this.auth.register(dto.email, dto.password, dto.role);
+    return { id: user.id, email: user.email, role: user.role };
+  }
+
   @Post('login')
-  async login(@Body() { email, password }: LoginDto) {
-    const userId = await this.auth.validateUser(email, password);
-    if (!userId) {
+  async login(
+    @Body() { email, password }: LoginDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const user = await this.auth.validateUser(email, password);
+    if (!user) {
       throw new UnauthorizedException();
     }
-    return { access_token: this.auth.sign(userId) };
+    const token = this.auth.sign(user.id);
+    res.cookie('token', token, { httpOnly: true });
+    if (user.role === UserRole.Admin) {
+      const basic = Buffer.from(`${email}:${password}`).toString('base64');
+      res.cookie('auth', basic, { httpOnly: true });
+    } else {
+      res.clearCookie('auth');
+    }
+    return { id: user.id, email: user.email, role: user.role };
+  }
+
+  @Post('logout')
+  async logout(@Res({ passthrough: true }) res: Response) {
+    res.clearCookie('token');
+    res.clearCookie('auth');
+    return {};
+  }
+
+  @Get('me')
+  async me(@Req() req: Request) {
+    const userId = (req as any).user?.sub;
+    if (!userId) throw new UnauthorizedException();
+    const user = await this.auth.getUser(userId);
+    if (!user) throw new UnauthorizedException();
+    return { id: user.id, email: user.email, role: user.role };
   }
 }

--- a/apps/api/src/auth/dto/register.dto.ts
+++ b/apps/api/src/auth/dto/register.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsString, IsOptional, IsEnum } from 'class-validator';
+import { UserRole } from '@prisma/client';
+
+export class RegisterDto {
+  @ApiProperty()
+  @IsEmail()
+  email!: string;
+
+  @ApiProperty()
+  @IsString()
+  password!: string;
+
+  @ApiProperty({ required: false, enum: UserRole })
+  @IsOptional()
+  @IsEnum(UserRole)
+  role?: UserRole;
+}

--- a/apps/api/src/auth/guards/auth.guard.ts
+++ b/apps/api/src/auth/guards/auth.guard.ts
@@ -7,12 +7,20 @@ export class AuthGuard implements CanActivate {
 
   canActivate(context: ExecutionContext): boolean {
     const req = context.switchToHttp().getRequest();
-    const openPaths = ['/auth/login', '/healthz', '/readyz'];
+    const openPaths = ['/auth/login', '/auth/register', '/auth/logout', '/healthz', '/readyz'];
     if (openPaths.includes(req.path)) {
       return true;
     }
     const authHeader = req.headers['authorization'] || '';
-    const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    const bearer = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    const cookies = (req.headers['cookie'] || '')
+      .split(';')
+      .map((c: string) => c.trim().split('='))
+      .reduce((acc: Record<string, string>, [k, v]) => {
+        if (k && v) acc[k] = decodeURIComponent(v);
+        return acc;
+      }, {} as Record<string, string>);
+    const token = cookies['token'] || bearer;
     if (!token) {
       throw new UnauthorizedException();
     }

--- a/apps/api/src/auth/guards/auth.guard.ts
+++ b/apps/api/src/auth/guards/auth.guard.ts
@@ -16,7 +16,7 @@ export class AuthGuard implements CanActivate {
     const cookies = (req.headers['cookie'] || '')
       .split(';')
       .map((c: string) => c.trim().split('='))
-      .reduce((acc: Record<string, string>, [k, v]) => {
+      .reduce((acc: Record<string, string>, [k, v]: [string, string]) => {
         if (k && v) acc[k] = decodeURIComponent(v);
         return acc;
       }, {} as Record<string, string>);

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -32,6 +32,12 @@ components:
         code: { type: string }
         message: { type: string }
         details: { type: object, additionalProperties: true }
+    User:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        email: { type: string }
+        role: { type: string, enum: [User, Admin] }
     Vault:
       type: object
       properties:
@@ -153,22 +159,28 @@ paths:
           description: OK
   /auth/register:
     post:
-      summary: Register user (MVP with 2FA; Passkeys in M1)
+      summary: Register user
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
+              required: [email, password]
               properties:
                 email: { type: string }
-                phone: { type: string, nullable: true }
                 password: { type: string }
+                role: { type: string, enum: [User, Admin] }
       responses:
-        '201': { description: Created }
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
   /auth/login:
     post:
-      summary: Login, returns JWT
+      summary: Login, sets JWT cookie
       requestBody:
         required: true
         content:
@@ -178,9 +190,33 @@ paths:
               properties:
                 email: { type: string }
                 password: { type: string }
-                otp: { type: string, description: "optional TOTP if 2FA enabled" }
       responses:
-        '200': { description: OK }
+        '200':
+          description: OK
+          headers:
+            Set-Cookie:
+              description: JWT httpOnly cookie
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  /auth/logout:
+    post:
+      summary: Clear auth cookies
+      responses:
+        '200': { description: Logged out }
+  /auth/me:
+    get:
+      summary: Get current user
+      responses:
+        '200':
+          description: Current user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401': { description: Unauthorized }
   /vaults:
     get:
       summary: List vaults


### PR DESCRIPTION
## Summary
- add user registration DTO and auth service methods
- issue JWT in httpOnly cookies and store admin Basic-auth
- expand OpenAPI with auth endpoints and user schema

## Testing
- `cd apps/api && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30a840bec83249d3854bfe7b2a3b3