### PR TITLE
feat(web): add admin login and logout pages

### DIFF
--- a/apps/web/src/app/adm/login/page.tsx
+++ b/apps/web/src/app/adm/login/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { httpClient } from '@/shared/api/httpClient';
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await httpClient('/auth/login', {
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        setError('Неверный логин или пароль');
+        return;
+      }
+      const data = await res.json().catch(() => ({}));
+      if (data.role === 'Admin') {
+        const encoded = btoa(`${email}:${password}`);
+        document.cookie = `auth=${encoded}; path=/`;
+        router.push('/adm');
+      } else {
+        setError('Нет доступа');
+      }
+    } catch {
+      setError('Ошибка соединения');
+    }
+  }
+
+  return (
+    <div className="p-6">
+      <h1 className="mb-4 text-2xl font-bold">Вход</h1>
+      <form onSubmit={handleSubmit} className="flex max-w-sm flex-col gap-4">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="rounded border p-2"
+        />
+        <input
+          type="password"
+          placeholder="Пароль"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="rounded border p-2"
+        />
+        {error && <p className="text-red-600">{error}</p>}
+        <button
+          type="submit"
+          className="rounded bg-blue-600 px-4 py-2 text-white"
+        >
+          Войти
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/apps/web/src/app/adm/logout/page.tsx
+++ b/apps/web/src/app/adm/logout/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function AdminLogoutPage() {
+  const router = useRouter();
+  useEffect(() => {
+    document.cookie = 'auth=; Max-Age=0; path=/';
+    router.replace('/adm/login');
+  }, [router]);
+  return null;
+}
+

--- a/docs/web.md
+++ b/docs/web.md
@@ -38,3 +38,13 @@ Authorization: Basic <base64(email:password)>
 ```
 
 Используйте учётные данные администратора из таблицы `user` (role `Admin`).
+
+Для входа существует страница `/adm/login`.
+Форма отправляет данные на `/auth/login`,
+при успешном ответе с ролью `Admin`
+устанавливает cookie `auth=<base64(email:password)>`
+и перенаправляет на `/adm`.
+
+Выйти из админки можно через `/adm/logout`,
+который очищает cookie `auth`
+и переадресует обратно на `/adm/login`.


### PR DESCRIPTION
## Summary
- add admin login page hitting `/auth/login` and setting `auth` cookie
- add admin logout page clearing `auth` cookie
- document admin login/logout flow

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint setup)

------
https://chatgpt.com/codex/tasks/task_e_68b30d265cc08324991c04107e915184