### PR TITLE
feat(web): add auth hook and integrate login/logout

### DIFF
--- a/apps/web/src/app/dev/logout/page.tsx
+++ b/apps/web/src/app/dev/logout/page.tsx
@@ -2,20 +2,22 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
+import { httpClient } from '@/shared/api/httpClient';
+import { auth } from '@/shared/auth/store';
 
 export default function LogoutPage() {
   const router = useRouter();
 
   useEffect(() => {
-    document.cookie.split(';').forEach((c) => {
-      document.cookie = c
-        .replace(/^ +/, '')
-        .replace(/=.*/, '=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/');
-    });
-    if (typeof window !== 'undefined') {
-      window.localStorage.clear();
-    }
-    router.replace('/dev');
+    (async () => {
+      try {
+        await httpClient('/auth/logout');
+      } catch {
+        // ignore errors
+      }
+      auth.logout();
+      router.replace('/dev');
+    })();
   }, [router]);
 
   return null;

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useAuth } from '@/shared/auth/useAuth';
 import {
   Home,
   Info,
@@ -13,20 +13,6 @@ import {
   LogOut,
 } from 'lucide-react';
 
-// Simple role detection using localStorage
-// Possible roles: guest (default), owner, verifier
-function useRole() {
-  const [role, setRole] = useState<'guest' | 'owner' | 'verifier'>('guest');
-
-  useEffect(() => {
-    const stored = window.localStorage.getItem('role');
-    if (stored === 'owner' || stored === 'verifier') {
-      setRole(stored);
-    }
-  }, []);
-
-  return role;
-}
 
 interface HeaderProps {
   bgColor: string;
@@ -34,7 +20,7 @@ interface HeaderProps {
 }
 
 export default function Header({ bgColor, textColor }: HeaderProps) {
-  const role = useRole();
+  const { role } = useAuth();
 
   const linkStyle = { color: textColor } as React.CSSProperties;
 

--- a/apps/web/src/shared/api/httpClient.ts
+++ b/apps/web/src/shared/api/httpClient.ts
@@ -1,3 +1,5 @@
+import { auth } from '../auth/store';
+
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || '/api';
 
 interface HttpClientOptions extends RequestInit {
@@ -25,7 +27,7 @@ export async function httpClient(
         const data = await res.clone().json();
         const role = data?.role;
         if (role === 'owner' || role === 'verifier') {
-          window.localStorage.setItem('role', role);
+          auth.login(role);
         }
       } catch {
         // ignore JSON parse errors

--- a/apps/web/src/shared/auth/store.ts
+++ b/apps/web/src/shared/auth/store.ts
@@ -1,0 +1,32 @@
+export type Role = 'guest' | 'owner' | 'verifier';
+
+type Listener = () => void;
+
+class AuthStore {
+  private role: Role = 'guest';
+  private listeners = new Set<Listener>();
+
+  subscribe(listener: Listener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  getRole() {
+    return this.role;
+  }
+
+  private setRole(role: Role) {
+    this.role = role;
+    for (const listener of this.listeners) listener();
+  }
+
+  login(role: Role) {
+    this.setRole(role);
+  }
+
+  logout() {
+    this.setRole('guest');
+  }
+}
+
+export const auth = new AuthStore();

--- a/apps/web/src/shared/auth/useAuth.ts
+++ b/apps/web/src/shared/auth/useAuth.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useSyncExternalStore } from 'react';
+import { auth, Role } from './store';
+import { httpClient } from '../api/httpClient';
+
+export function useAuth() {
+  const role = useSyncExternalStore(
+    auth.subscribe.bind(auth),
+    auth.getRole.bind(auth),
+    auth.getRole.bind(auth),
+  );
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await httpClient('/auth/me', { method: 'GET' });
+        if (res.ok) {
+          const data = await res.json().catch(() => ({}));
+          const role = data?.role;
+          if (role === 'owner' || role === 'verifier') {
+            auth.login(role);
+          } else {
+            auth.logout();
+          }
+        }
+      } catch {
+        // ignore errors
+      }
+    }
+    load();
+  }, []);
+
+  return {
+    role,
+    login: (r: Role) => auth.login(r),
+    logout: () => auth.logout(),
+  };
+}


### PR DESCRIPTION
## Summary
- add shared auth store and hook loading `/auth/me`
- update httpClient and components to use auth login/logout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompt for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68b30f89e4fc8324be62a05132bd9ac9