### PR TITLE
refactor: simplify header nav

### DIFF
--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -3,8 +3,6 @@
 import Link from 'next/link';
 import { useAuth } from '@/shared/auth/useAuth';
 import {
-  Home,
-  Info,
   FileText,
   Mail,
   User,
@@ -13,6 +11,7 @@ import {
   LogIn,
   LogOut,
 } from 'lucide-react';
+import { motion } from 'framer-motion';
 
 
 interface HeaderProps {
@@ -32,64 +31,87 @@ export default function Header({ bgColor, textColor }: HeaderProps) {
           Afterlight
         </Link>
         <ul className="flex flex-1 justify-center gap-4">
-          <li>
-            <Link href="/" className="flex items-center gap-1" style={linkStyle}>
-              <Home className="h-4 w-4" />
-              <span>Главная</span>
-            </Link>
-          </li>
-          <li>
-            <Link href="/how" className="flex items-center gap-1" style={linkStyle}>
-              <Info className="h-4 w-4" />
-              <span>Как это работает</span>
-            </Link>
-          </li>
-          <li>
+          <motion.li
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+            whileHover={{ scale: 1.05 }}
+          >
             <Link href="/policies" className="flex items-center gap-1" style={linkStyle}>
               <FileText className="h-4 w-4" />
               <span>Политики</span>
             </Link>
-          </li>
-          <li>
+          </motion.li>
+          <motion.li
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+            whileHover={{ scale: 1.05 }}
+          >
             <Link href="/contacts" className="flex items-center gap-1" style={linkStyle}>
               <Mail className="h-4 w-4" />
               <span>Контакты</span>
             </Link>
-          </li>
-          <li>
+          </motion.li>
+          <motion.li
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+            whileHover={{ scale: 1.05 }}
+          >
             <Link href="/owner" className="flex items-center gap-1" style={linkStyle}>
               <User className="h-4 w-4" />
               <span>Кабинет владельца</span>
             </Link>
-          </li>
-          <li>
+          </motion.li>
+          <motion.li
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+            whileHover={{ scale: 1.05 }}
+          >
             <Link href="/verifier" className="flex items-center gap-1" style={linkStyle}>
               <ShieldCheck className="h-4 w-4" />
               <span>Кабинет верификатора</span>
             </Link>
-          </li>
-          <li>
+          </motion.li>
+          <motion.li
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+            whileHover={{ scale: 1.05 }}
+          >
             <Link href="/adm" className="flex items-center gap-1" style={linkStyle}>
               <Shield className="h-4 w-4" />
               <span>Админка</span>
             </Link>
-          </li>
+          </motion.li>
         </ul>
         <ul className="flex gap-4">
           {role === 'guest' ? (
-            <li>
+            <motion.li
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+              whileHover={{ scale: 1.05 }}
+            >
               <Link href="/login" className="flex items-center gap-1" style={linkStyle}>
                 <LogIn className="h-4 w-4" />
                 <span>Войти</span>
               </Link>
-            </li>
+            </motion.li>
           ) : (
-            <li>
+            <motion.li
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+              whileHover={{ scale: 1.05 }}
+            >
               <Link href="/logout" className="flex items-center gap-1" style={linkStyle}>
                 <LogOut className="h-4 w-4" />
                 <span>Выйти</span>
               </Link>
-            </li>
+            </motion.li>
           )}
         </ul>
       </nav>


### PR DESCRIPTION
## Summary
- remove redundant home and how links from header
- animate menu items with framer-motion for hover and entrance
- confirm /how route no longer exists

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b32ef129308324bb0b4f77e1d54012