### PR TITLE
feat(web): add footer links for policies and contacts

### DIFF
--- a/apps/web/src/components/footer-links.tsx
+++ b/apps/web/src/components/footer-links.tsx
@@ -1,24 +1,58 @@
 'use client';
 
-import { FaTelegramPlane, FaGithub, FaCode } from 'react-icons/fa';
+import {
+  FaTelegramPlane,
+  FaGithub,
+  FaCode,
+  FaRegFileAlt,
+  FaEnvelope,
+} from 'react-icons/fa';
 
 interface Links {
   telegram: string;
   github: string;
   dev: string;
+  policies: string;
+  contacts: string;
 }
 
 export default function FooterLinks({ links }: { links: Links }) {
   return (
-    <div className="fixed bottom-6 left-1/2 flex -translate-x-1/2 gap-6">
-      <a href={links.telegram} aria-label="Telegram">
+    <div className="fixed bottom-6 left-1/2 flex -translate-x-1/2 gap-6 text-gray-400">
+      <a
+        href={links.telegram}
+        aria-label="Telegram"
+        className="transition-transform transition-colors hover:scale-110 hover:text-gray-200"
+      >
         <FaTelegramPlane className="h-6 w-6" />
       </a>
-      <a href={links.github} aria-label="GitHub">
+      <a
+        href={links.github}
+        aria-label="GitHub"
+        className="transition-transform transition-colors hover:scale-110 hover:text-gray-200"
+      >
         <FaGithub className="h-6 w-6" />
       </a>
-      <a href={links.dev} aria-label="Dev build">
+      <a
+        href={links.dev}
+        aria-label="Dev build"
+        className="transition-transform transition-colors hover:scale-110 hover:text-gray-200"
+      >
         <FaCode className="h-6 w-6" />
+      </a>
+      <a
+        href={links.policies}
+        aria-label="Policies"
+        className="transition-transform transition-colors hover:scale-110 hover:text-gray-200"
+      >
+        <FaRegFileAlt className="h-6 w-6" />
+      </a>
+      <a
+        href={links.contacts}
+        aria-label="Contacts"
+        className="transition-transform transition-colors hover:scale-110 hover:text-gray-200"
+      >
+        <FaEnvelope className="h-6 w-6" />
       </a>
     </div>
   );

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -2,15 +2,7 @@
 
 import Link from 'next/link';
 import { useAuth } from '@/shared/auth/useAuth';
-import {
-  FileText,
-  Mail,
-  User,
-  ShieldCheck,
-  Shield,
-  LogIn,
-  LogOut,
-} from 'lucide-react';
+import { User, ShieldCheck, Shield, LogIn, LogOut } from 'lucide-react';
 import { motion } from 'framer-motion';
 
 
@@ -31,28 +23,6 @@ export default function Header({ bgColor, textColor }: HeaderProps) {
           Afterlight
         </Link>
         <ul className="flex flex-1 justify-center gap-4">
-          <motion.li
-            initial={{ opacity: 0, y: -10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3 }}
-            whileHover={{ scale: 1.05 }}
-          >
-            <Link href="/policies" className="flex items-center gap-1" style={linkStyle}>
-              <FileText className="h-4 w-4" />
-              <span>Политики</span>
-            </Link>
-          </motion.li>
-          <motion.li
-            initial={{ opacity: 0, y: -10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3 }}
-            whileHover={{ scale: 1.05 }}
-          >
-            <Link href="/contacts" className="flex items-center gap-1" style={linkStyle}>
-              <Mail className="h-4 w-4" />
-              <span>Контакты</span>
-            </Link>
-          </motion.li>
           <motion.li
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}

--- a/apps/web/src/components/landing-content.tsx
+++ b/apps/web/src/components/landing-content.tsx
@@ -8,6 +8,8 @@ interface Links {
   telegram: string;
   github: string;
   dev: string;
+  policies: string;
+  contacts: string;
 }
 
 export default function LandingContent({ links }: { links: Links }) {

--- a/apps/web/src/lib/landing.ts
+++ b/apps/web/src/lib/landing.ts
@@ -19,6 +19,8 @@ export interface LandingConfig {
     telegram: string;
     github: string;
     dev: string;
+    policies: string;
+    contacts: string;
   };
 }
 
@@ -42,6 +44,8 @@ const defaultConfig: LandingConfig = {
     github: 'https://github.com/retrotink/afterlight',
     // route for development layout
     dev: '/',
+    policies: '/policies',
+    contacts: '/contacts',
   },
 };
 
@@ -76,6 +80,10 @@ export function getLandingConfig(): LandingConfig {
       telegram: process.env.LANDING_TELEGRAM || defaultConfig.links.telegram,
       github: process.env.LANDING_GITHUB || defaultConfig.links.github,
       dev: process.env.LANDING_DEV || defaultConfig.links.dev,
+      policies:
+        process.env.LANDING_POLICIES || defaultConfig.links.policies,
+      contacts:
+        process.env.LANDING_CONTACTS || defaultConfig.links.contacts,
     },
   };
 }
@@ -99,6 +107,8 @@ export async function saveLandingConfig(config: LandingConfig): Promise<void> {
   process.env.LANDING_TELEGRAM = config.links.telegram;
   process.env.LANDING_GITHUB = config.links.github;
   process.env.LANDING_DEV = config.links.dev;
+  process.env.LANDING_POLICIES = config.links.policies;
+  process.env.LANDING_CONTACTS = config.links.contacts;
 
   const envPath = path.join(process.cwd(), '.env.local');
   const lines = [
@@ -118,6 +128,8 @@ export async function saveLandingConfig(config: LandingConfig): Promise<void> {
     `LANDING_TELEGRAM=${config.links.telegram}`,
     `LANDING_GITHUB=${config.links.github}`,
     `LANDING_DEV=${config.links.dev}`,
+    `LANDING_POLICIES=${config.links.policies}`,
+    `LANDING_CONTACTS=${config.links.contacts}`,
   ];
   await fs.writeFile(envPath, lines.join('\n') + '\n', 'utf-8');
 }


### PR DESCRIPTION
## Summary
- drop policies and contacts links from top navigation
- add policy and contact icons to footer and source paths from config
- support policies and contacts links in landing config and env persistence

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b34a574ba0832486a36c2b2c7e969e