### PR TITLE
feat(web): remove basic auth header from middleware

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -3,10 +3,7 @@ import { httpClient } from './shared/api/httpClient';
 // Prisma cannot run in Edge middleware; use API route instead
 
 function unauthorized() {
-  return new NextResponse('Unauthorized', {
-    status: 401,
-    headers: { 'WWW-Authenticate': 'Basic realm="Secure Area"' },
-  });
+  return new NextResponse('Unauthorized', { status: 401 });
 }
 
 export async function middleware(req: NextRequest) {


### PR DESCRIPTION
## Summary
- remove `WWW-Authenticate` header from middleware unauthorized responses

## Testing
- `npm test` (fails: Missing script "test")
- `npx eslint .` (fails: ESLint couldn't find an eslint.config)
- `curl -i http://localhost:3000/adm`

------
https://chatgpt.com/codex/tasks/task_e_68b34a58ce5483248c184eddb8cfb52a