### PR TITLE
fix: add framer-motion dependency and link fields

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@noble/hashes": "^1.8.0",
         "@prisma/client": "^5.17.0",
+        "framer-motion": "^11.18.2",
         "lucide-react": "^0.539.0",
         "next": "14.2.5",
         "react": "18.3.1",
@@ -1109,6 +1110,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1426,6 +1454,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@noble/hashes": "^1.8.0",
     "@prisma/client": "^5.17.0",
+    "framer-motion": "^11.18.2",
     "lucide-react": "^0.539.0",
     "next": "14.2.5",
     "react": "18.3.1",

--- a/apps/web/src/app/adm/page.tsx
+++ b/apps/web/src/app/adm/page.tsx
@@ -35,6 +35,8 @@ export default function AdminPage() {
         telegram: (formData.get('telegram') as string) || '',
         github: (formData.get('github') as string) || '',
         dev: (formData.get('dev') as string) || '',
+        policies: (formData.get('policies') as string) || '',
+        contacts: (formData.get('contacts') as string) || '',
       },
     };
 
@@ -159,6 +161,24 @@ export default function AdminPage() {
           <input
             name="dev"
             defaultValue={config.links.dev}
+            placeholder="URL"
+            className="rounded p-2 text-black"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>Ссылка на политики</span>
+          <input
+            name="policies"
+            defaultValue={config.links.policies}
+            placeholder="URL"
+            className="rounded p-2 text-black"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>Ссылка для контактов</span>
+          <input
+            name="contacts"
+            defaultValue={config.links.contacts}
             placeholder="URL"
             className="rounded p-2 text-black"
           />

--- a/apps/web/src/app/api/landing/route.ts
+++ b/apps/web/src/app/api/landing/route.ts
@@ -97,6 +97,8 @@ export async function POST(request: Request) {
       telegram: body.links?.telegram ?? current.links.telegram,
       github: body.links?.github ?? current.links.github,
       dev: body.links?.dev ?? current.links.dev,
+      policies: body.links?.policies ?? current.links.policies,
+      contacts: body.links?.contacts ?? current.links.contacts,
     },
   };
   await saveLandingConfig(newConfig);

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -13,12 +13,12 @@ export default {
       },
       keyframes: {
         'card-fade': {
-          '0%': { opacity: 0, transform: 'translateY(10px)' },
-          '100%': { opacity: 1, transform: 'translateY(0)' },
+          '0%': { opacity: '0', transform: 'translateY(10px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
         },
         'icon-pop': {
-          '0%': { opacity: 0, transform: 'scale(0.8)' },
-          '100%': { opacity: 1, transform: 'scale(1)' },
+          '0%': { opacity: '0', transform: 'scale(0.8)' },
+          '100%': { opacity: '1', transform: 'scale(1)' },
         },
       },
       animation: {


### PR DESCRIPTION
## Summary
- add framer-motion dependency for landing animations
- extend landing config forms and API with policies and contacts links
- fix Tailwind keyframe typings for animations

## Testing
- `npm run lint` *(fails: requires initial configuration)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b32c8b349483248c45c59615736078