### PR TITLE
fix: add framer-motion dependency and link fields

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@noble/hashes": "^1.8.0",
         "@prisma/client": "^5.17.0",
+        "framer-motion": "^11.18.2",
         "lucide-react": "^0.539.0",
         "next": "14.2.5",
         "react": "18.3.1",
@@ -1109,6 +1110,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1426,6 +1454,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@noble/hashes": "^1.8.0",
     "@prisma/client": "^5.17.0",
+    "framer-motion": "^11.18.2",
     "lucide-react": "^0.539.0",
     "next": "14.2.5",
     "react": "18.3.1",

--- a/apps/web/src/app/adm/page.tsx
+++ b/apps/web/src/app/adm/page.tsx
@@ -35,6 +35,8 @@ export default function AdminPage() {
         telegram: (formData.get('telegram') as string) || '',
         github: (formData.get('github') as string) || '',
         dev: (formData.get('dev') as string) || '',
+        policies: (formData.get('policies') as string) || '',
+        contacts: (formData.get('contacts') as string) || '',
       },
     };
 
@@ -159,6 +161,24 @@ export default function AdminPage() {
           <input
             name="dev"
             defaultValue={config.links.dev}
+            placeholder="URL"
+            className="rounded p-2 text-black"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>Ссылка на политики</span>
+          <input
+            name="policies"
+            defaultValue={config.links.policies}
+            placeholder="URL"
+            className="rounded p-2 text-black"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>Ссылка для контактов</span>
+          <input
+            name="contacts"
+            defaultValue={config.links.contacts}
             placeholder="URL"
             className="rounded p-2 text-black"
           />

--- a/apps/web/src/app/api/landing/route.ts
+++ b/apps/web/src/app/api/landing/route.ts
@@ -97,6 +97,8 @@ export async function POST(request: Request) {
       telegram: body.links?.telegram ?? current.links.telegram,
       github: body.links?.github ?? current.links.github,
       dev: body.links?.dev ?? current.links.dev,
+      policies: body.links?.policies ?? current.links.policies,
+      contacts: body.links?.contacts ?? current.links.contacts,
     },
   };
   await saveLandingConfig(newConfig);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,8 +1,9 @@
 
 import FooterLinks from "@/components/footer-links";
+import FeatureCard from "@/components/feature-card";
+import FaqItem from "@/components/faq-item";
 import { getLandingConfig } from "@/lib/landing";
 import { Lock, Users, Activity, Link as LinkIcon } from "lucide-react";
-import { motion } from "framer-motion";
 
 
 export const dynamic = 'force-dynamic';
@@ -11,20 +12,35 @@ export default function Home() {
   const config = getLandingConfig();
   const features = [
     {
-      icon: Lock,
+      icon: <Lock className="feature-icon mb-2 h-6 w-6 text-accent" />,
       text: "Клиентское шифрование: мы не видим содержимое ваших сейфов.",
     },
     {
-      icon: Users,
+      icon: <Users className="feature-icon mb-2 h-6 w-6 text-accent" />,
       text: "Кворум 2 из 3 верификаторов подтверждает событие.",
     },
     {
-      icon: Activity,
+      icon: <Activity className="feature-icon mb-2 h-6 w-6 text-accent" />,
       text: "Heartbeat: год без входа запускает процесс вручения.",
     },
     {
-      icon: LinkIcon,
+      icon: <LinkIcon className="feature-icon mb-2 h-6 w-6 text-accent" />,
       text: "Публичные ссылки на блоки живут 24 часа и защищены CAPTCHA.",
+    },
+  ];
+
+  const faqs = [
+    {
+      q: "Как обеспечивается безопасность?",
+      a: "Содержимое шифруется на вашем устройстве. Мы храним только зашифрованные данные и технические метаданные.",
+    },
+    {
+      q: "Как подтверждается событие?",
+      a: "Двое из трёх доверенных людей подтверждают событие. После этого запускается раскрытие сейфа.",
+    },
+    {
+      q: "Есть ли контроль времени?",
+      a: "У вас сутки на финальные действия, а окно «я на связи» длится год.",
     },
   ];
   return (
@@ -41,17 +57,7 @@ export default function Home() {
         <h2 className="mb-4 text-2xl font-semibold">Фичи</h2>
         <div className="grid gap-4 sm:grid-cols-2">
           {features.map((f, i) => (
-            <motion.div
-              key={i}
-              className="feature-card card-fade"
-              initial={{ opacity: 0, y: 10 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.4, delay: i * 0.1 }}
-            >
-              <f.icon className="feature-icon mb-2 h-6 w-6 text-accent" />
-              <p className="text-sm">{f.text}</p>
-            </motion.div>
+            <FeatureCard key={i} icon={f.icon} text={f.text} delay={i * 0.1} />
           ))}
         </div>
       </section>
@@ -69,45 +75,9 @@ export default function Home() {
       <section className="mb-6">
         <h2 className="text-2xl font-semibold mb-4">FAQ</h2>
         <div className="space-y-4">
-          <motion.div
-            className="card-fade"
-            initial={{ opacity: 0, y: 10 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.4 }}
-          >
-            <h3 className="font-medium">Как обеспечивается безопасность?</h3>
-            <p>
-              Содержимое шифруется на вашем устройстве. Мы храним только
-              зашифрованные данные и технические метаданные.
-            </p>
-          </motion.div>
-          <motion.div
-            className="card-fade"
-            initial={{ opacity: 0, y: 10 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.4, delay: 0.1 }}
-          >
-            <h3 className="font-medium">Как подтверждается событие?</h3>
-            <p>
-              Двое из трёх доверенных людей подтверждают событие. После этого
-              запускается раскрытие сейфа.
-            </p>
-          </motion.div>
-          <motion.div
-            className="card-fade"
-            initial={{ opacity: 0, y: 10 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.4, delay: 0.2 }}
-          >
-            <h3 className="font-medium">Есть ли контроль времени?</h3>
-            <p>
-              У вас сутки на финальные действия, а окно «я на связи» длится
-              год.
-            </p>
-          </motion.div>
+          {faqs.map((f, i) => (
+            <FaqItem key={i} question={f.q} answer={f.a} delay={i * 0.1} />
+          ))}
         </div>
       </section>
 

--- a/apps/web/src/components/faq-item.tsx
+++ b/apps/web/src/components/faq-item.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+interface Props {
+  question: string;
+  answer: string;
+  delay?: number;
+}
+
+export default function FaqItem({ question, answer, delay = 0 }: Props) {
+  return (
+    <motion.div
+      className="card-fade"
+      initial={{ opacity: 0, y: 10 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.4, delay }}
+    >
+      <h3 className="font-medium">{question}</h3>
+      <p>{answer}</p>
+    </motion.div>
+  );
+}

--- a/apps/web/src/components/feature-card.tsx
+++ b/apps/web/src/components/feature-card.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import type { ReactNode } from 'react';
+
+interface Props {
+  icon: ReactNode;
+  text: string;
+  delay?: number;
+}
+
+export default function FeatureCard({ icon, text, delay = 0 }: Props) {
+  return (
+    <motion.div
+      className="feature-card card-fade"
+      initial={{ opacity: 0, y: 10 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.4, delay }}
+    >
+      {icon}
+      <p className="text-sm">{text}</p>
+    </motion.div>
+  );
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -13,12 +13,12 @@ export default {
       },
       keyframes: {
         'card-fade': {
-          '0%': { opacity: 0, transform: 'translateY(10px)' },
-          '100%': { opacity: 1, transform: 'translateY(0)' },
+          '0%': { opacity: '0', transform: 'translateY(10px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
         },
         'icon-pop': {
-          '0%': { opacity: 0, transform: 'scale(0.8)' },
-          '100%': { opacity: 1, transform: 'scale(1)' },
+          '0%': { opacity: '0', transform: 'scale(0.8)' },
+          '100%': { opacity: '1', transform: 'scale(1)' },
         },
       },
       animation: {


### PR DESCRIPTION
## Summary
- add framer-motion dependency for landing animations
- extend landing config forms and API with policies and contacts links
- fix Tailwind keyframe typings for animations
- render animated landing content via client-only components

## Testing
- `npm run lint` *(fails: next lint requires initial configuration)*
- `npm run build`
- `curl http://localhost:4000 | head -c 4000`


------
https://chatgpt.com/codex/tasks/task_e_68b32c8b349483248c45c59615736078