### PR TITLE
feat(web): add Bodaghee palette and fonts

### DIFF
--- a/apps/web/public/fonts/README.md
+++ b/apps/web/public/fonts/README.md
@@ -1,0 +1,7 @@
+Place proprietary font files here before building:
+
+- MadeforText-Regular.woff2
+- DINNextLight.woff2
+
+These fonts are not included in the repository. Obtain the licensed files and
+copy them into this directory to enable proper font loading.

--- a/apps/web/src/app/adm/login/page.tsx
+++ b/apps/web/src/app/adm/login/page.tsx
@@ -37,26 +37,26 @@ export default function AdminLoginPage() {
 
   return (
     <div className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">Вход</h1>
+      <h1 className="mb-4 text-2xl">Вход</h1>
       <form onSubmit={handleSubmit} className="flex max-w-sm flex-col gap-4">
         <input
           type="email"
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="rounded border p-2"
+          className="rounded border p-2 text-bodaghee-navy"
         />
         <input
           type="password"
           placeholder="Пароль"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="rounded border p-2"
+          className="rounded border p-2 text-bodaghee-navy"
         />
-        {error && <p className="text-red-600">{error}</p>}
+        {error && <p className="text-bodaghee-lime">{error}</p>}
         <button
           type="submit"
-          className="rounded bg-blue-600 px-4 py-2 text-white"
+          className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy"
         >
           Войти
         </button>

--- a/apps/web/src/app/adm/page.tsx
+++ b/apps/web/src/app/adm/page.tsx
@@ -48,7 +48,7 @@ export default function AdminPage() {
 
   return (
     <main className="flex min-h-screen flex-col items-center p-6">
-      <h1 className="mb-4 text-2xl font-bold">Настройки титульной страницы</h1>
+      <h1 className="mb-4 text-2xl">Настройки титульной страницы</h1>
       <form action={saveConfig} className="flex w-full max-w-xl flex-col gap-4">
         <label className="flex flex-col gap-1">
           <span>Название проекта</span>
@@ -56,7 +56,7 @@ export default function AdminPage() {
             <input
               name="title"
               defaultValue={config.title}
-              className="flex-1 rounded p-2 text-black"
+              className="flex-1 rounded border p-2 text-bodaghee-navy"
             />
             <input type="color" name="titleColor" defaultValue={config.titleColor} />
           </div>
@@ -67,7 +67,7 @@ export default function AdminPage() {
             <input
               name="subtitle"
               defaultValue={config.subtitle}
-              className="flex-1 rounded p-2 text-black"
+              className="flex-1 rounded border p-2 text-bodaghee-navy"
             />
             <input type="color" name="subtitleColor" defaultValue={config.subtitleColor} />
           </div>
@@ -78,7 +78,7 @@ export default function AdminPage() {
             <input
               name="description"
               defaultValue={config.description}
-              className="flex-1 rounded p-2 text-black"
+              className="flex-1 rounded border p-2 text-bodaghee-navy"
             />
             <input
               type="color"
@@ -140,50 +140,50 @@ export default function AdminPage() {
         </div>
         <label className="flex flex-col gap-1">
           <span>Ссылка Telegram</span>
-          <input
-            name="telegram"
-            defaultValue={config.links.telegram}
-            placeholder="URL"
-            className="rounded p-2 text-black"
-          />
+            <input
+              name="telegram"
+              defaultValue={config.links.telegram}
+              placeholder="URL"
+              className="rounded border p-2 text-bodaghee-navy"
+            />
         </label>
         <label className="flex flex-col gap-1">
           <span>Ссылка GitHub</span>
-          <input
-            name="github"
-            defaultValue={config.links.github}
-            placeholder="URL"
-            className="rounded p-2 text-black"
-          />
+            <input
+              name="github"
+              defaultValue={config.links.github}
+              placeholder="URL"
+              className="rounded border p-2 text-bodaghee-navy"
+            />
         </label>
         <label className="flex flex-col gap-1">
           <span>Ссылка dev build</span>
-          <input
-            name="dev"
-            defaultValue={config.links.dev}
-            placeholder="URL"
-            className="rounded p-2 text-black"
-          />
+            <input
+              name="dev"
+              defaultValue={config.links.dev}
+              placeholder="URL"
+              className="rounded border p-2 text-bodaghee-navy"
+            />
         </label>
         <label className="flex flex-col gap-1">
           <span>Ссылка на политики</span>
-          <input
-            name="policies"
-            defaultValue={config.links.policies}
-            placeholder="URL"
-            className="rounded p-2 text-black"
-          />
+            <input
+              name="policies"
+              defaultValue={config.links.policies}
+              placeholder="URL"
+              className="rounded border p-2 text-bodaghee-navy"
+            />
         </label>
         <label className="flex flex-col gap-1">
           <span>Ссылка для контактов</span>
-          <input
-            name="contacts"
-            defaultValue={config.links.contacts}
-            placeholder="URL"
-            className="rounded p-2 text-black"
-          />
+            <input
+              name="contacts"
+              defaultValue={config.links.contacts}
+              placeholder="URL"
+              className="rounded border p-2 text-bodaghee-navy"
+            />
         </label>
-        <button type="submit" className="rounded bg-green-600 px-4 py-2 text-white">
+        <button type="submit" className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy">
           Сохранить
         </button>
       </form>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2,24 +2,28 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: dark;
-  --color-bg: #0a0a0a;
-  --color-card: #1a1a1a;
-  --color-text: #f5f5f5;
-  --color-accent: #6366f1;
-}
-
 html,
 body {
   min-height: 100%;
 }
 
 body {
-  background-color: var(--color-bg);
-  color: var(--color-text);
+  @apply bg-bodaghee-teal text-bodaghee-navy font-body;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  @apply text-bodaghee-lime underline-offset-4 hover:underline;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  @apply font-heading text-bodaghee-navy;
 }
 
 @keyframes card-fade {
@@ -44,20 +48,8 @@ body {
   }
 }
 
-.feature-card {
-  background-color: var(--color-card);
-  border: 1px solid #262626;
-  border-radius: 0.5rem;
-  padding: 1rem;
-  transition: border-color 0.2s;
-}
-
 .card-fade {
   animation: card-fade 0.6s ease both;
-}
-
-.feature-card:hover {
-  border-color: var(--color-accent);
 }
 
 .feature-icon {
@@ -65,6 +57,14 @@ body {
   transition: transform 0.2s;
 }
 
-.feature-card:hover .feature-icon {
-  transform: scale(1.1);
+@layer utilities {
+  .font-heading {
+    font-family: var(--font-heading), sans-serif;
+  }
+  .font-body {
+    font-family: var(--font-body), sans-serif;
+  }
+  .font-numeric {
+    font-family: var(--font-numeric), sans-serif;
+  }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,9 +3,26 @@ import type { Metadata } from 'next';
 import Header from '@/components/header';
 import Footer from '@/components/footer';
 import { getLandingConfig } from '@/lib/landing';
-import { Inter } from 'next/font/google';
+import { Questrial } from 'next/font/google';
+import localFont from 'next/font/local';
 
-const inter = Inter({ subsets: ['latin', 'cyrillic'] });
+const headingFont = Questrial({
+  subsets: ['latin'],
+  weight: '400',
+  variable: '--font-heading',
+});
+
+const bodyFont = localFont({
+  src: '../../public/fonts/MadeforText-Regular.woff2',
+  weight: '400',
+  variable: '--font-body',
+});
+
+const numericFont = localFont({
+  src: '../../public/fonts/DINNextLight.woff2',
+  weight: '300',
+  variable: '--font-numeric',
+});
 
 export const metadata: Metadata = {
   title: 'AfterLight — разработка',
@@ -19,7 +36,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ru">
       <body
-        className={`${inter.className} flex min-h-screen flex-col antialiased`}
+        className={`${headingFont.variable} ${bodyFont.variable} ${numericFont.variable} flex min-h-screen flex-col antialiased font-body`}
         style={{ backgroundColor: config.bgColor }}
       >
         <Header bgColor={config.headerBgColor} textColor={config.headerTextColor} />

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -56,33 +56,33 @@ export default function LoginPage() {
 
   return (
     <div className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">Вход</h1>
+      <h1 className="mb-4 text-2xl">Вход</h1>
       <form onSubmit={handleSubmit} className="flex max-w-sm flex-col gap-4">
         <input
           type="email"
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="rounded border p-2"
+          className="rounded border p-2 text-bodaghee-navy"
         />
         <input
           type="password"
           placeholder="Пароль"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="rounded border p-2"
+          className="rounded border p-2 text-bodaghee-navy"
         />
         <input
           type="text"
           placeholder="OTP (если включен)"
           value={otp}
           onChange={(e) => setOtp(e.target.value)}
-          className="rounded border p-2"
+          className="rounded border p-2 text-bodaghee-navy"
         />
-        {error && <p className="text-red-600">{error}</p>}
+        {error && <p className="text-bodaghee-lime">{error}</p>}
         <button
           type="submit"
-          className="rounded bg-blue-600 px-4 py-2 text-white"
+          className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy"
         >
           Войти
         </button>

--- a/apps/web/src/app/owner/page.tsx
+++ b/apps/web/src/app/owner/page.tsx
@@ -111,15 +111,15 @@ export default function OwnerPage() {
   };
   if (role !== "owner") {
     return <div className="p-6">Доступ запрещён</div>;
-  }
+    }
 
-  return (
+    return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">Личный кабинет</h1>
+      <h1 className="mb-4 text-2xl">Личный кабинет</h1>
 
       <div className="mb-4">
         <button
-          className="rounded bg-blue-600 px-4 py-2 text-white"
+          className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy"
           onClick={() => setShowModal(true)}
         >
           Новый сейф
@@ -127,7 +127,7 @@ export default function OwnerPage() {
       </div>
 
       {vaultsLoading && <p>Загрузка...</p>}
-      {vaultsError && <p className="text-red-500">{vaultsError}</p>}
+        {vaultsError && <p className="text-bodaghee-lime">{vaultsError}</p>}
       {!vaultsLoading && !vaultsError && (
         <table className="min-w-full border text-sm">
           <thead>
@@ -150,9 +150,9 @@ export default function OwnerPage() {
       )}
 
       <div className="mt-8">
-        <h2 className="text-xl font-bold mb-2">Верификаторы</h2>
+        <h2 className="mb-2 text-xl">Верификаторы</h2>
         {verifiersLoading && <p>Загрузка...</p>}
-        {verifiersError && <p className="text-red-500">{verifiersError}</p>}
+        {verifiersError && <p className="text-bodaghee-lime">{verifiersError}</p>}
         {!verifiersLoading && !verifiersError && (
           <ul className="mb-4 list-disc pl-5">
             {verifiers.map((v: any, idx: number) => (
@@ -164,35 +164,35 @@ export default function OwnerPage() {
         <div className="flex gap-2">
           <input
             type="email"
-            className="border p-2 flex-grow"
+            className="flex-grow border p-2 text-bodaghee-navy"
             placeholder="email"
             value={inviteEmail}
             onChange={(e) => setInviteEmail(e.target.value)}
           />
           <button
-            className="rounded bg-blue-600 px-4 py-2 text-white"
+            className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy"
             onClick={handleInvite}
             disabled={inviting}
           >
             Пригласить
           </button>
         </div>
-        {inviteError && <p className="text-red-500 mt-2">{inviteError}</p>}
+          {inviteError && <p className="mt-2 text-bodaghee-lime">{inviteError}</p>}
       </div>
 
       {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-          <div className="bg-white p-6 rounded max-w-md w-full">
-            <h2 className="text-xl font-bold mb-4">Новый сейф</h2>
+        <div className="fixed inset-0 flex items-center justify-center bg-bodaghee-navy/50">
+          <div className="w-full max-w-md rounded bg-bodaghee-teal p-6 text-bodaghee-navy">
+            <h2 className="mb-4 text-xl">Новый сейф</h2>
             <div className="space-y-2">
-              <input
-                className="w-full border p-2"
-                placeholder="Название сейфа"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-              />
+                <input
+                  className="w-full border p-2 text-bodaghee-navy"
+                  placeholder="Название сейфа"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                />
               <textarea
-                className="w-full border p-2"
+                className="w-full border p-2 text-bodaghee-navy"
                 placeholder="Описание (необязательно)"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
@@ -201,7 +201,7 @@ export default function OwnerPage() {
                 <input
                   key={idx}
                   type="email"
-                  className="w-full border p-2"
+                  className="w-full border p-2 text-bodaghee-navy"
                   placeholder={`Верификатор ${idx + 1} (e-mail)`}
                   value={email}
                   onChange={(e) => {
@@ -211,7 +211,7 @@ export default function OwnerPage() {
                   }}
                 />
               ))}
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-bodaghee-navy/70">
                 Добавьте три человека, которым вы доверяете. Доступ откроется при
                 подтверждении двух из них.
               </p>
@@ -219,18 +219,18 @@ export default function OwnerPage() {
                 type="number"
                 min={1}
                 max={3}
-                className="w-full border p-2"
+                className="w-full border p-2 text-bodaghee-navy"
                 value={quorum}
                 onChange={(e) => setQuorum(Number(e.target.value))}
               />
             </div>
-            {createError && <p className="text-red-500 mt-2">{createError}</p>}
+              {createError && <p className="mt-2 text-bodaghee-lime">{createError}</p>}
             <div className="mt-4 flex justify-end gap-2">
-              <button className="px-4 py-2" onClick={() => setShowModal(false)}>
-                Отмена
-              </button>
-              <button
-                className="rounded bg-blue-600 px-4 py-2 text-white"
+                <button className="px-4 py-2" onClick={() => setShowModal(false)}>
+                  Отмена
+                </button>
+                <button
+                className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy"
                 onClick={handleCreate}
                 disabled={creating}
               >

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -9,19 +9,19 @@ export const dynamic = 'force-dynamic';
 export default function Home() {
   const features = [
     {
-      icon: <Lock className="feature-icon mb-2 h-6 w-6 text-accent" />,
+      icon: <Lock className="feature-icon mb-2 h-6 w-6 text-bodaghee-lime" />,
       text: "Клиентское шифрование: мы не видим содержимое ваших сейфов.",
     },
     {
-      icon: <Users className="feature-icon mb-2 h-6 w-6 text-accent" />,
+      icon: <Users className="feature-icon mb-2 h-6 w-6 text-bodaghee-lime" />,
       text: "Кворум 2 из 3 верификаторов подтверждает событие.",
     },
     {
-      icon: <Activity className="feature-icon mb-2 h-6 w-6 text-accent" />,
+      icon: <Activity className="feature-icon mb-2 h-6 w-6 text-bodaghee-lime" />,
       text: "Heartbeat: год без входа запускает процесс вручения.",
     },
     {
-      icon: <LinkIcon className="feature-icon mb-2 h-6 w-6 text-accent" />,
+      icon: <LinkIcon className="feature-icon mb-2 h-6 w-6 text-bodaghee-lime" />,
       text: "Публичные ссылки на блоки живут 24 часа и защищены CAPTCHA.",
     },
   ];
@@ -83,14 +83,14 @@ export default function Home() {
 
       <section className="mb-6">
         <h2 className="text-2xl font-semibold mb-4">FAQ</h2>
-        <div className="max-h-64 space-y-4 overflow-y-auto rounded border bg-white p-4">
+        <div className="max-h-64 space-y-4 overflow-y-auto rounded border border-bodaghee-navy/20 bg-bodaghee-teal p-4 text-bodaghee-navy">
           {faqs.map((f, i) => (
             <FaqItem key={i} question={f.q} answer={f.a} delay={i * 0.1} />
           ))}
         </div>
       </section>
 
-      <p className="text-sm text-gray-500">
+      <p className="text-sm text-bodaghee-navy/70">
         Содержимое шифруется на вашем устройстве. Мы храним только
         зашифрованные данные и технические метаданные.
       </p>

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -31,33 +31,33 @@ export default function RegisterPage() {
 
   return (
     <div className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">Регистрация</h1>
+      <h1 className="mb-4 text-2xl">Регистрация</h1>
       <form onSubmit={handleSubmit} className="flex max-w-sm flex-col gap-4">
         <input
           type="email"
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="rounded border p-2"
+          className="rounded border p-2 text-bodaghee-navy"
         />
         <input
           type="tel"
           placeholder="Телефон (опционально)"
           value={phone}
           onChange={(e) => setPhone(e.target.value)}
-          className="rounded border p-2"
+          className="rounded border p-2 text-bodaghee-navy"
         />
         <input
           type="password"
           placeholder="Пароль"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="rounded border p-2"
+          className="rounded border p-2 text-bodaghee-navy"
         />
-        {error && <p className="text-red-600">{error}</p>}
+        {error && <p className="text-bodaghee-lime">{error}</p>}
         <button
           type="submit"
-          className="rounded bg-blue-600 px-4 py-2 text-white"
+          className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy"
         >
           Зарегистрироваться
         </button>

--- a/apps/web/src/app/verifier/page.tsx
+++ b/apps/web/src/app/verifier/page.tsx
@@ -47,7 +47,7 @@ export default function VerifierPage() {
     const confirms = e.confirmsCount ?? e.confirmations ?? 0;
     const denies = e.deniesCount ?? e.denials ?? 0;
     return (
-      <div className="text-sm text-gray-600">
+      <div className="text-sm text-bodaghee-navy/70">
         Подтверждения: {confirms} / Отказы: {denies}
       </div>
     );
@@ -59,25 +59,25 @@ export default function VerifierPage() {
 
   return (
     <div className="p-6 space-y-4">
-      <h1 className="text-2xl font-bold">Кабинет верификатора</h1>
-      <p className="text-sm text-gray-600">
+      <h1 className="mb-2 text-2xl">Кабинет верификатора</h1>
+      <p className="text-sm text-bodaghee-navy/70">
         Требуется 2 подтверждения из 3. Публичная ссылка активна 24 часа.
       </p>
       {events.map(e => (
-        <div key={e.id} className="border rounded p-4 space-y-2">
+        <div key={e.id} className="space-y-2 rounded border p-4 text-bodaghee-navy">
           <div className="font-mono text-sm">ID: {e.id}</div>
           <div>Состояние: {e.state}</div>
           {renderCounters(e)}
           <div className="space-x-2">
             <button
               onClick={() => handleAction(e.id, 'confirm')}
-              className="bg-green-500 text-white px-2 py-1 rounded"
+              className="rounded bg-bodaghee-teal px-2 py-1 text-bodaghee-navy"
             >
               Подтвердить
             </button>
             <button
               onClick={() => handleAction(e.id, 'deny')}
-              className="bg-red-500 text-white px-2 py-1 rounded"
+              className="rounded bg-bodaghee-teal px-2 py-1 text-bodaghee-lime"
             >
               Отклонить
             </button>

--- a/apps/web/src/components/faq-item.tsx
+++ b/apps/web/src/components/faq-item.tsx
@@ -11,13 +11,13 @@ interface Props {
 export default function FaqItem({ question, answer, delay = 0 }: Props) {
   return (
     <motion.div
-      className="card-fade"
+      className="card-fade rounded bg-bodaghee-teal p-4 text-bodaghee-navy"
       initial={{ opacity: 0, y: 10 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.4, delay }}
     >
-      <h3 className="font-medium">{question}</h3>
+      <h3 className="mb-2">{question}</h3>
       <p>{answer}</p>
     </motion.div>
   );

--- a/apps/web/src/components/feature-card.tsx
+++ b/apps/web/src/components/feature-card.tsx
@@ -12,13 +12,13 @@ interface Props {
 export default function FeatureCard({ icon, text, delay = 0 }: Props) {
   return (
     <motion.div
-      className="feature-card card-fade"
+      className="card-fade group rounded border border-bodaghee-navy/20 bg-bodaghee-teal p-4 text-bodaghee-navy hover:border-bodaghee-lime"
       initial={{ opacity: 0, y: 10 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.4, delay }}
     >
-      {icon}
+      <div className="feature-icon mb-2 text-bodaghee-lime group-hover:scale-110">{icon}</div>
       <p className="text-sm">{text}</p>
     </motion.div>
   );

--- a/apps/web/src/components/landing-content.tsx
+++ b/apps/web/src/components/landing-content.tsx
@@ -67,13 +67,13 @@ export default function LandingContent() {
           {features.map((f, i) => (
             <motion.div
               key={i}
-              className="feature-card"
+              className="card-fade group rounded border border-bodaghee-navy/20 bg-bodaghee-teal p-4 text-bodaghee-navy hover:border-bodaghee-lime"
               initial={{ opacity: 0, y: 10 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: i * 0.1 }}
             >
-              <f.icon className="feature-icon mb-2 h-6 w-6 text-accent" />
+              <f.icon className="feature-icon mb-2 h-6 w-6 text-bodaghee-lime group-hover:scale-110" />
               <p className="text-sm">{f.text}</p>
             </motion.div>
           ))}
@@ -92,14 +92,14 @@ export default function LandingContent() {
 
       <section className="mb-6">
         <h2 className="text-2xl font-semibold mb-4">FAQ</h2>
-        <div className="max-h-64 space-y-4 overflow-y-auto rounded border bg-white p-4">
+        <div className="max-h-64 space-y-4 overflow-y-auto rounded border border-bodaghee-navy/20 bg-bodaghee-teal p-4 text-bodaghee-navy">
           {faqs.map((f, i) => (
             <FaqItem key={i} question={f.q} answer={f.a} delay={i * 0.1} />
           ))}
         </div>
       </section>
 
-      <p className="text-sm text-gray-500">
+      <p className="text-sm text-bodaghee-navy/70">
         Содержимое шифруется на вашем устройстве. Мы храним только
         зашифрованные данные и технические метаданные.
       </p>

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import colors from 'tailwindcss/colors';
 
 export default {
   darkMode: 'class',
@@ -6,10 +7,10 @@ export default {
   theme: {
     extend: {
       colors: {
-        bg: 'var(--color-bg)',
-        card: 'var(--color-card)',
-        accent: 'var(--color-accent)',
-        text: 'var(--color-text)',
+        'bodaghee-navy': '#203549',
+        'bodaghee-teal': '#92CBDB',
+        'bodaghee-lime': '#DCFD35',
+        gray: colors.neutral,
       },
       keyframes: {
         'card-fade': {


### PR DESCRIPTION
## Summary
- add Bodaghee navy, teal and lime to Tailwind theme
- wire up Questrial, Madefor Text and DIN Next Light fonts
- refresh global styles and components to use new palette
- document fonts directory; binaries must be added manually

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: missing font files)*

------
https://chatgpt.com/codex/tasks/task_e_68b3622cd674832492a6876e5351b688