### PR TITLE
feat: enhance landing with network hero and stats

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -14,6 +14,7 @@
         "lucide-react": "^0.539.0",
         "next": "14.2.5",
         "react": "18.3.1",
+        "react-countup": "^6.5.3",
         "react-dom": "18.3.1",
         "react-icons": "^4.12.0"
       },
@@ -857,6 +858,12 @@
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
+    },
+    "node_modules/countup.js": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.9.0.tgz",
+      "integrity": "sha512-llqrvyXztRFPp6+i8jx25phHWcVWhrHO4Nlt0uAOSKHB8778zzQswa4MU3qKBvkXfJKftRYFJuVHez67lyKdHg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1982,6 +1989,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-countup": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/react-countup/-/react-countup-6.5.3.tgz",
+      "integrity": "sha512-udnqVQitxC7QWADSPDOxVWULkLvKUWrDapn5i53HE4DPRVgs+Y5rr4bo25qEl8jSh+0l2cToJgGMx+clxPM3+w==",
+      "license": "MIT",
+      "dependencies": {
+        "countup.js": "^2.8.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
       }
     },
     "node_modules/react-dom": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^0.539.0",
     "next": "14.2.5",
     "react": "18.3.1",
+    "react-countup": "^6.5.3",
     "react-dom": "18.3.1",
     "react-icons": "^4.12.0"
   },

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,29 +1,41 @@
+"use client";
 
-import FeatureCard from "@/components/feature-card";
-import FaqItem from "@/components/faq-item";
-import { Lock, Users, Activity, Link as LinkIcon } from "lucide-react";
+import dynamic from 'next/dynamic';
+import Link from 'next/link';
+import FeatureCard from '@/components/feature-card';
+import FaqItem from '@/components/faq-item';
+import Stats from '@/components/stats';
+import { motion, useReducedMotion } from 'framer-motion';
+import { Lock, Users, Activity, Link as LinkIcon } from 'lucide-react';
 
-
-export const dynamic = 'force-dynamic';
+const NetworkMesh = dynamic(() => import('@/components/network-mesh'), { ssr: false });
 
 export default function Home() {
+  const reduceMotion = useReducedMotion();
   const features = [
     {
       icon: <Lock className="feature-icon mb-2 h-6 w-6 text-bodaghee-lime" />,
-      text: "Клиентское шифрование: мы не видим содержимое ваших сейфов.",
+      text: 'Клиентское шифрование: мы не видим содержимое ваших сейфов.',
     },
     {
       icon: <Users className="feature-icon mb-2 h-6 w-6 text-bodaghee-lime" />,
-      text: "Кворум 2 из 3 верификаторов подтверждает событие.",
+      text: 'Кворум 2 из 3 верификаторов подтверждает событие.',
     },
     {
       icon: <Activity className="feature-icon mb-2 h-6 w-6 text-bodaghee-lime" />,
-      text: "Heartbeat: год без входа запускает процесс вручения.",
+      text: 'Heartbeat: год без входа запускает процесс вручения.',
     },
     {
       icon: <LinkIcon className="feature-icon mb-2 h-6 w-6 text-bodaghee-lime" />,
-      text: "Публичные ссылки на блоки живут 24 часа и защищены CAPTCHA.",
+      text: 'Публичные ссылки на блоки живут 24 часа и защищены CAPTCHA.',
     },
+  ];
+
+  const stats = [
+    { value: 2, suffix: '/3', label: 'кворум' },
+    { value: 365, suffix: ' дней', label: 'heartbeat' },
+    { value: 24, suffix: ' часа', label: 'grace-период' },
+    { value: 24, suffix: ' часа', label: 'жизнь ссылки' },
   ];
 
   const faqs = [
@@ -52,47 +64,70 @@ export default function Home() {
       a: 'Ссылка активна 24 часа, защищена CAPTCHA и удаляется после истечения срока.',
     },
   ];
-  return (
-    <div className="mx-auto max-w-2xl px-4 py-8 sm:px-8">
-      <h1 className="mb-4 text-3xl font-bold">
-        Afterlight — цифровое завещание под вашим контролем
-      </h1>
-      <p className="mb-6 text-lg">
-        Сохраните зашифрованные инструкции и файлы, которые увидят ваши
-        доверенные люди после подтверждённого события.
-      </p>
 
-      <section className="mb-8">
-        <h2 className="mb-4 text-2xl font-semibold">Ключевые возможности</h2>
-        <div className="grid gap-4 sm:grid-cols-2">
+  return (
+    <div className="flex flex-col">
+      <section className="container mx-auto flex flex-col items-center gap-8 px-4 py-16 sm:px-8 md:flex-row">
+        <div className="w-full text-center md:w-1/2 md:text-left">
+          <h1 className="mb-4 text-4xl font-bold">Afterlight — цифровое завещание</h1>
+          <p className="mb-6 text-lg">
+            Сохраните зашифрованные инструкции и файлы, которые увидят ваши
+            доверенные люди после подтверждённого события.
+          </p>
+          <Link
+            href="/register"
+            className="inline-block rounded bg-bodaghee-lime px-6 py-3 font-medium text-bodaghee-navy hover:bg-bodaghee-lime/90"
+          >
+            Создать сейф
+          </Link>
+        </div>
+        <div className="h-64 w-full md:h-80 md:w-1/2">
+          <NetworkMesh />
+        </div>
+      </section>
+
+      <motion.section
+        className="container mx-auto px-4 py-16 sm:px-8"
+        initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
+        whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={reduceMotion ? undefined : { duration: 0.4 }}
+      >
+        <h2 className="mb-4 text-2xl font-semibold">Преимущества</h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {features.map((f, i) => (
             <FeatureCard key={i} icon={f.icon} text={f.text} delay={i * 0.1} />
           ))}
         </div>
-      </section>
+      </motion.section>
 
-      <h2 className="mb-4 text-2xl font-semibold">Как это работает (3 шага)</h2>
-      <ol className="mb-6 list-decimal space-y-2 pl-5">
-        <li>Создайте сейф и добавьте 3 верификаторов.</li>
-        <li>Настройте блоки и получателей.</li>
-        <li>
-          При наступлении события два подтверждения запускают раскрытие. Через
-          24 часа доступ будет открыт.
-        </li>
-      </ol>
+      <motion.section
+        className="container mx-auto px-4 py-16 sm:px-8"
+        initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
+        whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={reduceMotion ? undefined : { duration: 0.4 }}
+      >
+        <Stats items={stats} />
+      </motion.section>
 
-      <section className="mb-6">
-        <h2 className="text-2xl font-semibold mb-4">FAQ</h2>
+      <motion.section
+        className="container mx-auto px-4 py-16 sm:px-8"
+        initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
+        whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={reduceMotion ? undefined : { duration: 0.4 }}
+      >
+        <h2 className="mb-4 text-2xl font-semibold">FAQ</h2>
         <div className="max-h-64 space-y-4 overflow-y-auto rounded border border-bodaghee-navy/20 bg-bodaghee-teal p-4 text-bodaghee-navy">
           {faqs.map((f, i) => (
             <FaqItem key={i} question={f.q} answer={f.a} delay={i * 0.1} />
           ))}
         </div>
-      </section>
+      </motion.section>
 
-      <p className="text-sm text-bodaghee-navy/70">
-        Содержимое шифруется на вашем устройстве. Мы храним только
-        зашифрованные данные и технические метаданные.
+      <p className="mx-auto mb-16 max-w-2xl px-4 text-sm text-bodaghee-navy/70 sm:px-8">
+        Содержимое шифруется на вашем устройстве. Мы храним только зашифрованные данные и технические метаданные.
       </p>
     </div>
   );

--- a/apps/web/src/components/faq-item.tsx
+++ b/apps/web/src/components/faq-item.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 
 interface Props {
   question: string;
@@ -9,13 +9,14 @@ interface Props {
 }
 
 export default function FaqItem({ question, answer, delay = 0 }: Props) {
+  const reduceMotion = useReducedMotion();
   return (
     <motion.div
       className="card-fade rounded bg-bodaghee-teal p-4 text-bodaghee-navy"
-      initial={{ opacity: 0, y: 10 }}
-      whileInView={{ opacity: 1, y: 0 }}
+      initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
+      whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
       viewport={{ once: true }}
-      transition={{ duration: 0.4, delay }}
+      transition={reduceMotion ? undefined : { duration: 0.4, delay }}
     >
       <h3 className="mb-2">{question}</h3>
       <p>{answer}</p>

--- a/apps/web/src/components/feature-card.tsx
+++ b/apps/web/src/components/feature-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import type { ReactNode } from 'react';
 
 interface Props {
@@ -10,13 +10,14 @@ interface Props {
 }
 
 export default function FeatureCard({ icon, text, delay = 0 }: Props) {
+  const reduceMotion = useReducedMotion();
   return (
     <motion.div
       className="card-fade group rounded border border-bodaghee-navy/20 bg-bodaghee-teal p-4 text-bodaghee-navy hover:border-bodaghee-lime"
-      initial={{ opacity: 0, y: 10 }}
-      whileInView={{ opacity: 1, y: 0 }}
+      initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
+      whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
       viewport={{ once: true }}
-      transition={{ duration: 0.4, delay }}
+      transition={reduceMotion ? undefined : { duration: 0.4, delay }}
     >
       <div className="feature-icon mb-2 text-bodaghee-lime group-hover:scale-110">{icon}</div>
       <p className="text-sm">{text}</p>

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import Link from 'next/link';
 import { FaTelegramPlane, FaGithub, FaRegFileAlt, FaEnvelope } from 'react-icons/fa';
-import { Shield } from 'lucide-react';
 
 interface Links {
   telegram: string;
@@ -14,59 +12,58 @@ interface Links {
 export default function Footer({ links }: { links: Links }) {
   return (
     <footer className="bg-gray-200 text-gray-700">
-      <nav className="container mx-auto flex justify-center p-4">
-        <ul className="flex gap-6 text-sm">
-          <li>
-            <a
-              href={links.telegram}
-              className="flex items-center gap-1 hover:text-gray-900"
-              aria-label="Telegram"
-            >
-              <FaTelegramPlane className="h-4 w-4" />
-              <span>Telegram</span>
-            </a>
-          </li>
-          <li>
-            <a
-              href={links.github}
-              className="flex items-center gap-1 hover:text-gray-900"
-              aria-label="GitHub"
-            >
-              <FaGithub className="h-4 w-4" />
-              <span>GitHub</span>
-            </a>
-          </li>
-          <li>
-            <a
-              href={links.policies}
-              className="flex items-center gap-1 hover:text-gray-900"
-              aria-label="Policies"
-            >
-              <FaRegFileAlt className="h-4 w-4" />
-              <span>Политики</span>
-            </a>
-          </li>
-          <li>
-            <a
-              href={links.contacts}
-              className="flex items-center gap-1 hover:text-gray-900"
-              aria-label="Contacts"
-            >
-              <FaEnvelope className="h-4 w-4" />
-              <span>Контакты</span>
-            </a>
-          </li>
-          <li>
-            <Link
-              href="/adm"
-              className="flex items-center gap-1 hover:text-gray-900"
-            >
-              <Shield className="h-4 w-4" />
-              <span>Админка</span>
-            </Link>
-          </li>
-        </ul>
-      </nav>
+      <div className="container mx-auto grid gap-8 px-4 py-8 text-sm sm:grid-cols-2">
+        <div>
+          <h3 className="mb-2 font-semibold uppercase">Inquiries</h3>
+          <ul className="space-y-2">
+            <li>
+              <a
+                href={links.contacts}
+                className="flex items-center gap-2 hover:text-gray-900"
+                aria-label="Contacts"
+              >
+                <FaEnvelope className="h-4 w-4" />
+                <span>Контакты</span>
+              </a>
+            </li>
+            <li>
+              <a
+                href={links.telegram}
+                className="flex items-center gap-2 hover:text-gray-900"
+                aria-label="Telegram"
+              >
+                <FaTelegramPlane className="h-4 w-4" />
+                <span>Telegram</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="mb-2 font-semibold uppercase">Links</h3>
+          <ul className="space-y-2">
+            <li>
+              <a
+                href={links.policies}
+                className="flex items-center gap-2 hover:text-gray-900"
+                aria-label="Policies"
+              >
+                <FaRegFileAlt className="h-4 w-4" />
+                <span>Политики</span>
+              </a>
+            </li>
+            <li>
+              <a
+                href={links.github}
+                className="flex items-center gap-2 hover:text-gray-900"
+                aria-label="GitHub"
+              >
+                <FaGithub className="h-4 w-4" />
+                <span>GitHub</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
     </footer>
   );
 }

--- a/apps/web/src/components/network-mesh.tsx
+++ b/apps/web/src/components/network-mesh.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+
+export default function NetworkMesh() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const resize = () => {
+      canvas.width = canvas.offsetWidth;
+      canvas.height = canvas.offsetHeight;
+    };
+    resize();
+
+    const nodes = Array.from({ length: 25 }, () => ({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      vx: (Math.random() - 0.5) * 0.5,
+      vy: (Math.random() - 0.5) * 0.5,
+    }));
+
+    const mouse = { x: 0, y: 0, active: false };
+
+    let frame: number;
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      nodes.forEach((n, idx) => {
+        if (!prefersReduced) {
+          n.x += n.vx;
+          n.y += n.vy;
+          if (n.x < 0 || n.x > canvas.width) n.vx *= -1;
+          if (n.y < 0 || n.y > canvas.height) n.vy *= -1;
+        }
+        const dist = mouse.active ? Math.hypot(n.x - mouse.x, n.y - mouse.y) : Infinity;
+        const radius = dist < 60 ? 4 : 2;
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, radius, 0, Math.PI * 2);
+        ctx.fillStyle = '#DCFD35';
+        ctx.fill();
+        for (let j = idx + 1; j < nodes.length; j++) {
+          const m = nodes[j];
+          const d = Math.hypot(n.x - m.x, n.y - m.y);
+          if (d < 80) {
+            ctx.strokeStyle = 'rgba(220,253,53,0.2)';
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(n.x, n.y);
+            ctx.lineTo(m.x, m.y);
+            ctx.stroke();
+          }
+        }
+      });
+      frame = requestAnimationFrame(draw);
+    };
+    draw();
+
+    const handleMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      mouse.x = e.clientX - rect.left;
+      mouse.y = e.clientY - rect.top;
+      mouse.active = true;
+    };
+    const handleLeave = () => {
+      mouse.active = false;
+    };
+
+    canvas.addEventListener('mousemove', handleMove);
+    canvas.addEventListener('mouseleave', handleLeave);
+    window.addEventListener('resize', resize);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      canvas.removeEventListener('mousemove', handleMove);
+      canvas.removeEventListener('mouseleave', handleLeave);
+      window.removeEventListener('resize', resize);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="h-full w-full" />;
+}
+

--- a/apps/web/src/components/stats.tsx
+++ b/apps/web/src/components/stats.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import CountUp from 'react-countup';
+
+interface Stat {
+  value: number;
+  suffix?: string;
+  label: string;
+}
+
+export default function Stats({ items }: { items: Stat[] }) {
+  const reduceMotion = useReducedMotion();
+  return (
+    <div className="grid grid-cols-2 gap-6 sm:grid-cols-4">
+      {items.map((s, i) => (
+        <motion.div
+          key={i}
+          className="text-center"
+          initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
+          whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={reduceMotion ? undefined : { duration: 0.4, delay: i * 0.1 }}
+        >
+          <div className="font-numeric text-3xl font-bold text-bodaghee-lime">
+            {reduceMotion ? (
+              <span>
+                {s.value}
+                {s.suffix}
+              </span>
+            ) : (
+              <CountUp end={s.value} suffix={s.suffix} duration={1.2} />
+            )}
+          </div>
+          <p className="text-sm text-bodaghee-navy">{s.label}</p>
+        </motion.div>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add animated NetworkMesh hero with CTA and dynamic import
- introduce Stats counters and improved FeatureCard/FAQ motion handling
- redesign footer with inquiries/links columns

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b36cd5a00c8324b45b9a7b963a61d8