### PR TITLE
feat(ui): refresh auth and dashboard pages

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -57,32 +57,35 @@ export default function LoginPage() {
   return (
     <div className="p-6">
       <h1 className="mb-4 text-2xl">Вход</h1>
-      <form onSubmit={handleSubmit} className="flex max-w-sm flex-col gap-4">
+      <form
+        onSubmit={handleSubmit}
+        className="flex max-w-sm flex-col gap-4 font-body"
+      >
         <input
           type="email"
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="rounded border p-2 text-bodaghee-navy"
+          className="rounded border border-bodaghee-navy bg-white/80 p-2 text-bodaghee-navy placeholder:text-bodaghee-navy/50 transition-colors focus:border-bodaghee-lime focus:bg-white"
         />
         <input
           type="password"
           placeholder="Пароль"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="rounded border p-2 text-bodaghee-navy"
+          className="rounded border border-bodaghee-navy bg-white/80 p-2 text-bodaghee-navy placeholder:text-bodaghee-navy/50 transition-colors focus:border-bodaghee-lime focus:bg-white"
         />
         <input
           type="text"
           placeholder="OTP (если включен)"
           value={otp}
           onChange={(e) => setOtp(e.target.value)}
-          className="rounded border p-2 text-bodaghee-navy"
+          className="rounded border border-bodaghee-navy bg-white/80 p-2 text-bodaghee-navy placeholder:text-bodaghee-navy/50 transition-colors focus:border-bodaghee-lime focus:bg-white"
         />
         {error && <p className="text-bodaghee-lime">{error}</p>}
         <button
           type="submit"
-          className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy"
+          className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy transition-colors hover:bg-bodaghee-lime"
         >
           Войти
         </button>

--- a/apps/web/src/app/logout/page.tsx
+++ b/apps/web/src/app/logout/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { motion } from 'framer-motion';
 import { useEffect } from 'react';
 import { httpClient } from '@/shared/api/httpClient';
 import { auth } from '@/shared/auth/store';
@@ -20,6 +21,16 @@ export default function LogoutPage() {
     })();
   }, [router]);
 
-  return null;
+  return (
+    <div className="flex min-h-screen items-center justify-center p-6 font-body text-bodaghee-navy">
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="text-center"
+      >
+        Выход...
+      </motion.div>
+    </div>
+  );
 }
 

--- a/apps/web/src/app/owner/page.tsx
+++ b/apps/web/src/app/owner/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { httpClient } from "@/shared/api/httpClient";
 import { useAuth } from "@/shared/auth/useAuth";
+import { AnimatePresence, motion } from "framer-motion";
 
 export default function OwnerPage() {
   const { role } = useAuth();
@@ -111,15 +112,15 @@ export default function OwnerPage() {
   };
   if (role !== "owner") {
     return <div className="p-6">Доступ запрещён</div>;
-    }
+  }
 
-    return (
-    <div className="p-6">
+  return (
+    <div className="p-6 space-y-8 font-body">
       <h1 className="mb-4 text-2xl">Личный кабинет</h1>
 
-      <div className="mb-4">
+      <div>
         <button
-          className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy"
+          className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy transition-colors hover:bg-bodaghee-lime"
           onClick={() => setShowModal(true)}
         >
           Новый сейф
@@ -127,119 +128,143 @@ export default function OwnerPage() {
       </div>
 
       {vaultsLoading && <p>Загрузка...</p>}
-        {vaultsError && <p className="text-bodaghee-lime">{vaultsError}</p>}
+      {vaultsError && <p className="text-bodaghee-lime">{vaultsError}</p>}
       {!vaultsLoading && !vaultsError && (
-        <table className="min-w-full border text-sm">
-          <thead>
-            <tr className="border-b">
-              <th className="p-2 text-left">ID</th>
-              <th className="p-2 text-left">Название</th>
-              <th className="p-2 text-left">Описание</th>
-            </tr>
-          </thead>
-          <tbody>
+        <div className="grid gap-4 md:grid-cols-2">
+          <AnimatePresence>
             {vaults.map((v: any) => (
-              <tr key={v.id} className="border-b">
-                <td className="p-2">{v.id}</td>
-                <td className="p-2">{v.name}</td>
-                <td className="p-2">{v.description}</td>
-              </tr>
+              <motion.div
+                key={v.id}
+                layout
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                className="rounded bg-bodaghee-teal p-4 text-bodaghee-navy shadow"
+              >
+                <div className="font-bold">{v.name || v.id}</div>
+                {v.description && <div className="text-sm">{v.description}</div>}
+              </motion.div>
             ))}
-          </tbody>
-        </table>
+          </AnimatePresence>
+        </div>
       )}
 
-      <div className="mt-8">
+      <div>
         <h2 className="mb-2 text-xl">Верификаторы</h2>
         {verifiersLoading && <p>Загрузка...</p>}
         {verifiersError && <p className="text-bodaghee-lime">{verifiersError}</p>}
         {!verifiersLoading && !verifiersError && (
-          <ul className="mb-4 list-disc pl-5">
-            {verifiers.map((v: any, idx: number) => (
-              <li key={idx}>{v.email || v.verifier?.contact}</li>
-            ))}
-          </ul>
+          <div className="grid gap-4 md:grid-cols-2">
+            <AnimatePresence>
+              {verifiers.map((v: any, idx: number) => (
+                <motion.div
+                  key={idx}
+                  layout
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -10 }}
+                  className="rounded bg-bodaghee-teal p-4 text-bodaghee-navy shadow"
+                >
+                  {v.email || v.verifier?.contact}
+                </motion.div>
+              ))}
+            </AnimatePresence>
+          </div>
         )}
 
-        <div className="flex gap-2">
+        <div className="mt-4 flex flex-col gap-2 sm:flex-row">
           <input
             type="email"
-            className="flex-grow border p-2 text-bodaghee-navy"
+            className="flex-grow rounded border border-bodaghee-navy bg-white/80 p-2 text-bodaghee-navy placeholder:text-bodaghee-navy/50 transition-colors focus:border-bodaghee-lime focus:bg-white"
             placeholder="email"
             value={inviteEmail}
             onChange={(e) => setInviteEmail(e.target.value)}
           />
           <button
-            className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy"
+            className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy transition-colors hover:bg-bodaghee-lime"
             onClick={handleInvite}
             disabled={inviting}
           >
             Пригласить
           </button>
         </div>
-          {inviteError && <p className="mt-2 text-bodaghee-lime">{inviteError}</p>}
+        {inviteError && <p className="mt-2 text-bodaghee-lime">{inviteError}</p>}
       </div>
 
-      {showModal && (
-        <div className="fixed inset-0 flex items-center justify-center bg-bodaghee-navy/50">
-          <div className="w-full max-w-md rounded bg-bodaghee-teal p-6 text-bodaghee-navy">
-            <h2 className="mb-4 text-xl">Новый сейф</h2>
-            <div className="space-y-2">
+      <AnimatePresence>
+        {showModal && (
+          <motion.div
+            className="fixed inset-0 flex items-center justify-center bg-bodaghee-navy/50 p-4"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <motion.div
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              className="w-full max-w-lg rounded bg-bodaghee-teal p-6 text-bodaghee-navy"
+            >
+              <h2 className="mb-4 text-xl">Новый сейф</h2>
+              <div className="grid gap-2 sm:grid-cols-2">
                 <input
-                  className="w-full border p-2 text-bodaghee-navy"
+                  className="col-span-full rounded border border-bodaghee-navy bg-white/80 p-2 text-bodaghee-navy placeholder:text-bodaghee-navy/50 transition-colors focus:border-bodaghee-lime focus:bg-white"
                   placeholder="Название сейфа"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                 />
-              <textarea
-                className="w-full border p-2 text-bodaghee-navy"
-                placeholder="Описание (необязательно)"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-              />
-              {verifierEmails.map((email, idx) => (
-                <input
-                  key={idx}
-                  type="email"
-                  className="w-full border p-2 text-bodaghee-navy"
-                  placeholder={`Верификатор ${idx + 1} (e-mail)`}
-                  value={email}
-                  onChange={(e) => {
-                    const next = [...verifierEmails];
-                    next[idx] = e.target.value;
-                    setVerifierEmails(next);
-                  }}
+                <textarea
+                  className="col-span-full rounded border border-bodaghee-navy bg-white/80 p-2 text-bodaghee-navy placeholder:text-bodaghee-navy/50 transition-colors focus:border-bodaghee-lime focus:bg-white"
+                  placeholder="Описание (необязательно)"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
                 />
-              ))}
-              <p className="text-sm text-bodaghee-navy/70">
-                Добавьте три человека, которым вы доверяете. Доступ откроется при
-                подтверждении двух из них.
-              </p>
-              <input
-                type="number"
-                min={1}
-                max={3}
-                className="w-full border p-2 text-bodaghee-navy"
-                value={quorum}
-                onChange={(e) => setQuorum(Number(e.target.value))}
-              />
-            </div>
+                {verifierEmails.map((email, idx) => (
+                  <input
+                    key={idx}
+                    type="email"
+                    className="rounded border border-bodaghee-navy bg-white/80 p-2 text-bodaghee-navy placeholder:text-bodaghee-navy/50 transition-colors focus:border-bodaghee-lime focus:bg-white"
+                    placeholder={`Верификатор ${idx + 1} (e-mail)`}
+                    value={email}
+                    onChange={(e) => {
+                      const next = [...verifierEmails];
+                      next[idx] = e.target.value;
+                      setVerifierEmails(next);
+                    }}
+                  />
+                ))}
+                <p className="col-span-full text-sm text-bodaghee-navy/70">
+                  Добавьте три человека, которым вы доверяете. Доступ откроется при подтверждении двух из них.
+                </p>
+                <input
+                  type="number"
+                  min={1}
+                  max={3}
+                  className="col-span-full rounded border border-bodaghee-navy bg-white/80 p-2 text-bodaghee-navy transition-colors focus:border-bodaghee-lime focus:bg-white"
+                  value={quorum}
+                  onChange={(e) => setQuorum(Number(e.target.value))}
+                />
+              </div>
               {createError && <p className="mt-2 text-bodaghee-lime">{createError}</p>}
-            <div className="mt-4 flex justify-end gap-2">
-                <button className="px-4 py-2" onClick={() => setShowModal(false)}>
+              <div className="mt-4 flex justify-end gap-2">
+                <button
+                  className="rounded px-4 py-2 transition-colors hover:bg-bodaghee-lime/20"
+                  onClick={() => setShowModal(false)}
+                >
                   Отмена
                 </button>
                 <button
-                className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy"
-                onClick={handleCreate}
-                disabled={creating}
-              >
-                Создать
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+                  className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy transition-colors hover:bg-bodaghee-lime"
+                  onClick={handleCreate}
+                  disabled={creating}
+                >
+                  Создать
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -32,32 +32,35 @@ export default function RegisterPage() {
   return (
     <div className="p-6">
       <h1 className="mb-4 text-2xl">Регистрация</h1>
-      <form onSubmit={handleSubmit} className="flex max-w-sm flex-col gap-4">
+      <form
+        onSubmit={handleSubmit}
+        className="flex max-w-sm flex-col gap-4 font-body"
+      >
         <input
           type="email"
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="rounded border p-2 text-bodaghee-navy"
+          className="rounded border border-bodaghee-navy bg-white/80 p-2 text-bodaghee-navy placeholder:text-bodaghee-navy/50 transition-colors focus:border-bodaghee-lime focus:bg-white"
         />
         <input
           type="tel"
           placeholder="Телефон (опционально)"
           value={phone}
           onChange={(e) => setPhone(e.target.value)}
-          className="rounded border p-2 text-bodaghee-navy"
+          className="rounded border border-bodaghee-navy bg-white/80 p-2 text-bodaghee-navy placeholder:text-bodaghee-navy/50 transition-colors focus:border-bodaghee-lime focus:bg-white"
         />
         <input
           type="password"
           placeholder="Пароль"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="rounded border p-2 text-bodaghee-navy"
+          className="rounded border border-bodaghee-navy bg-white/80 p-2 text-bodaghee-navy placeholder:text-bodaghee-navy/50 transition-colors focus:border-bodaghee-lime focus:bg-white"
         />
         {error && <p className="text-bodaghee-lime">{error}</p>}
         <button
           type="submit"
-          className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy"
+          className="rounded bg-bodaghee-teal px-4 py-2 text-bodaghee-navy transition-colors hover:bg-bodaghee-lime"
         >
           Зарегистрироваться
         </button>

--- a/apps/web/src/app/verifier/page.tsx
+++ b/apps/web/src/app/verifier/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { httpClient } from '@/shared/api/httpClient';
 import { useAuth } from '@/shared/auth/useAuth';
+import { AnimatePresence, motion } from 'framer-motion';
 
 interface VerificationEvent {
   id: string;
@@ -53,37 +54,59 @@ export default function VerifierPage() {
     );
   };
 
+  const statusMap: Record<string, { label: string; color: string }> = {
+    pending: { label: 'ожидает', color: 'bg-bodaghee-teal' },
+    confirmed: { label: 'подтверждено', color: 'bg-bodaghee-lime' },
+  };
+
   if (role !== 'verifier') {
     return <div className="p-6">Доступ запрещён</div>;
   }
 
   return (
-    <div className="p-6 space-y-4">
+    <div className="p-6 space-y-4 font-body">
       <h1 className="mb-2 text-2xl">Кабинет верификатора</h1>
       <p className="text-sm text-bodaghee-navy/70">
         Требуется 2 подтверждения из 3. Публичная ссылка активна 24 часа.
       </p>
-      {events.map(e => (
-        <div key={e.id} className="space-y-2 rounded border p-4 text-bodaghee-navy">
-          <div className="font-mono text-sm">ID: {e.id}</div>
-          <div>Состояние: {e.state}</div>
-          {renderCounters(e)}
-          <div className="space-x-2">
-            <button
-              onClick={() => handleAction(e.id, 'confirm')}
-              className="rounded bg-bodaghee-teal px-2 py-1 text-bodaghee-navy"
-            >
-              Подтвердить
-            </button>
-            <button
-              onClick={() => handleAction(e.id, 'deny')}
-              className="rounded bg-bodaghee-teal px-2 py-1 text-bodaghee-lime"
-            >
-              Отклонить
-            </button>
-          </div>
-        </div>
-      ))}
+      <div className="space-y-4">
+        <AnimatePresence>
+          {events.map(e => {
+            const status = statusMap[e.state] || { label: e.state, color: 'bg-gray-400' };
+            return (
+              <motion.div
+                key={e.id}
+                layout
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                className="space-y-2 rounded bg-bodaghee-teal p-4 text-bodaghee-navy shadow"
+              >
+                <div className="font-mono text-sm">ID: {e.id}</div>
+                <div className="flex items-center gap-2">
+                  <span className={`h-3 w-3 rounded-full ${status.color}`} />
+                  <span>{status.label}</span>
+                </div>
+                {renderCounters(e)}
+                <div className="space-x-2">
+                  <button
+                    onClick={() => handleAction(e.id, 'confirm')}
+                    className="rounded bg-bodaghee-teal px-2 py-1 text-bodaghee-navy transition-colors hover:bg-bodaghee-lime"
+                  >
+                    Подтвердить
+                  </button>
+                  <button
+                    onClick={() => handleAction(e.id, 'deny')}
+                    className="rounded bg-bodaghee-teal px-2 py-1 text-bodaghee-lime transition-colors hover:bg-bodaghee-lime/80"
+                  >
+                    Отклонить
+                  </button>
+                </div>
+              </motion.div>
+            );
+          })}
+        </AnimatePresence>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- style auth forms with design kit colors and hover transitions
- animate owner vault/verifier cards and modal with framer-motion
- add status indicators and palette updates for verifier dashboard

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`
- `npm run dev` *(manually terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_68b3719ff2748324b61c3d7ab7603576