### PR TITLE
feat: add animated navbar and hero

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -35,8 +35,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   const config = getLandingConfig();
   return (
     <html lang="ru">
-      <body className={`${headingFont.variable} ${bodyFont.variable} ${numericFont.variable} flex min-h-screen flex-col antialiased font-body`}>
-        <Header bgColor={config.headerBgColor} textColor={config.headerTextColor} />
+      <body
+        className={`${headingFont.variable} ${bodyFont.variable} ${numericFont.variable} flex min-h-screen flex-col antialiased font-body`}
+      >
+        <Header />
         <main className="flex-grow">{children}</main>
         <Footer links={config.links} />
       </body>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -67,21 +67,18 @@ export default function Home() {
 
   return (
     <div className="flex flex-col">
-      <section className="container mx-auto flex flex-col items-center gap-8 px-4 py-16 sm:px-8 md:flex-row">
-        <div className="w-full text-center md:w-1/2 md:text-left">
-          <h1 className="mb-4 text-4xl font-bold">Afterlight — цифровое завещание</h1>
-          <p className="mb-6 text-lg">
-            Сохраните зашифрованные инструкции и файлы, которые увидят ваши
-            доверенные люди после подтверждённого события.
-          </p>
+      <section className="container mx-auto grid items-center gap-8 px-4 py-16 sm:px-8 md:grid-cols-2">
+        <div className="flex flex-col items-center text-center md:items-start md:text-left">
+          <h1 className="mb-4 text-[86px] font-heading text-white">Afterlight</h1>
+          <p className="mb-6 text-xl text-bodaghee-accent">Цифровое завещание</p>
           <Link
             href="/register"
-            className="inline-block rounded border border-bodaghee-accent bg-bodaghee-bg px-6 py-3 font-medium text-white transition-colors hover:bg-bodaghee-accent hover:text-bodaghee-bg"
+            className="inline-block border border-bodaghee-accent px-6 py-3 text-bodaghee-accent transition-colors hover:bg-bodaghee-accent hover:text-bodaghee-bg"
           >
             Создать сейф
           </Link>
         </div>
-        <div className="h-64 w-full md:h-80 md:w-1/2">
+        <div className="relative h-64 w-full md:h-full">
           <NetworkMesh />
         </div>
       </section>

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,79 +1,107 @@
-'use client';
+"use client";
 
-import Link from 'next/link';
-import { useAuth } from '@/shared/auth/useAuth';
-import { User, ShieldCheck, LogIn, LogOut } from 'lucide-react';
-import { motion } from 'framer-motion';
+import { useState, type ReactNode } from "react";
+import Link from "next/link";
+import { useAuth } from "@/shared/auth/useAuth";
+import {
+  User,
+  ShieldCheck,
+  LogIn,
+  LogOut,
+  Menu,
+  X,
+} from "lucide-react";
+import { motion } from "framer-motion";
 
-
-interface HeaderProps {
-  bgColor: string;
-  textColor: string;
-}
-
-export default function Header({ bgColor, textColor }: HeaderProps) {
+export default function Header() {
   const { role } = useAuth();
+  const [open, setOpen] = useState(false);
 
-  const linkStyle = { color: textColor } as React.CSSProperties;
+  const mainLinks = [
+    {
+      href: "/owner",
+      label: "Кабинет пользователя",
+      icon: <User className="h-4 w-4" />,
+    },
+    {
+      href: "/verifier",
+      label: "Кабинет верификатора",
+      icon: <ShieldCheck className="h-4 w-4" />,
+    },
+  ];
+
+  const authLinks =
+    role === "guest"
+      ? [{ href: "/login", label: "Войти", icon: <LogIn className="h-4 w-4" /> }]
+      : [{ href: "/logout", label: "Выйти", icon: <LogOut className="h-4 w-4" /> }];
+
+  const NavItem = ({
+    href,
+    label,
+    icon,
+  }: { href: string; label: string; icon: ReactNode }) => (
+    <motion.div
+      className="relative flex items-center gap-1"
+      initial="rest"
+      whileHover="hover"
+      animate="rest"
+    >
+      <Link
+        href={href}
+        className="text-sm font-body uppercase text-white"
+      >
+        {icon}
+        <span>{label}</span>
+      </Link>
+      <motion.span
+        variants={{ rest: { scaleX: 0 }, hover: { scaleX: 1 } }}
+        transition={{ duration: 0.3 }}
+        className="absolute left-0 -bottom-0.5 h-px w-full origin-left bg-bodaghee-accent"
+      />
+    </motion.div>
+  );
 
   return (
-    <header style={{ backgroundColor: bgColor }}>
-      <nav className="container mx-auto flex items-center p-4">
-        <Link href="/" className="text-xl font-bold" style={linkStyle}>
+    <header className="sticky top-0 z-50 bg-bodaghee-bg/80">
+      <nav className="container mx-auto flex items-center justify-between p-4">
+        <Link href="/" className="text-xl font-bold text-white">
           Afterlight
         </Link>
-        <ul className="flex flex-1 justify-center gap-4">
-          <motion.li
-            initial={{ opacity: 0, y: -10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3 }}
-            whileHover={{ scale: 1.05 }}
-          >
-            <Link href="/owner" className="flex items-center gap-1" style={linkStyle}>
-              <User className="h-4 w-4" />
-              <span>Кабинет пользователя</span>
-            </Link>
-          </motion.li>
-          <motion.li
-            initial={{ opacity: 0, y: -10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3 }}
-            whileHover={{ scale: 1.05 }}
-          >
-            <Link href="/verifier" className="flex items-center gap-1" style={linkStyle}>
-              <ShieldCheck className="h-4 w-4" />
-              <span>Кабинет верификатора</span>
-            </Link>
-          </motion.li>
-        </ul>
-        <ul className="flex gap-4">
-          {role === 'guest' ? (
-            <motion.li
-              initial={{ opacity: 0, y: -10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.3 }}
-              whileHover={{ scale: 1.05 }}
-            >
-              <Link href="/login" className="flex items-center gap-1" style={linkStyle}>
-                <LogIn className="h-4 w-4" />
-                <span>Войти</span>
-              </Link>
-            </motion.li>
+        <div className="hidden flex-1 justify-center gap-6 md:flex">
+          {mainLinks.map((l) => (
+            <NavItem key={l.href} {...l} />
+          ))}
+        </div>
+        <div className="hidden gap-6 md:flex">
+          {authLinks.map((l) => (
+            <NavItem key={l.href} {...l} />
+          ))}
+        </div>
+        <button
+          className="md:hidden"
+          aria-label="Toggle menu"
+          onClick={() => setOpen((o) => !o)}
+        >
+          {open ? (
+            <X className="h-6 w-6 text-white" />
           ) : (
-            <motion.li
-              initial={{ opacity: 0, y: -10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.3 }}
-              whileHover={{ scale: 1.05 }}
-            >
-              <Link href="/logout" className="flex items-center gap-1" style={linkStyle}>
-                <LogOut className="h-4 w-4" />
-                <span>Выйти</span>
-              </Link>
-            </motion.li>
+            <Menu className="h-6 w-6 text-white" />
           )}
-        </ul>
+        </button>
       </nav>
+      {open && (
+        <motion.div
+          initial={{ height: 0, opacity: 0 }}
+          animate={{ height: "auto", opacity: 1 }}
+          className="md:hidden bg-bodaghee-bg/80"
+        >
+          <div className="container mx-auto flex flex-col items-center gap-4 p-4">
+            {[...mainLinks, ...authLinks].map((l) => (
+              <NavItem key={l.href} {...l} />
+            ))}
+          </div>
+        </motion.div>
+      )}
     </header>
   );
 }

--- a/apps/web/src/components/network-mesh.tsx
+++ b/apps/web/src/components/network-mesh.tsx
@@ -19,7 +19,7 @@ export default function NetworkMesh() {
     };
     resize();
 
-    const nodes = Array.from({ length: 25 }, () => ({
+    const nodes = Array.from({ length: 50 }, () => ({
       x: Math.random() * canvas.width,
       y: Math.random() * canvas.height,
       vx: (Math.random() - 0.5) * 0.5,
@@ -39,17 +39,23 @@ export default function NetworkMesh() {
           if (n.y < 0 || n.y > canvas.height) n.vy *= -1;
         }
         const dist = mouse.active ? Math.hypot(n.x - mouse.x, n.y - mouse.y) : Infinity;
-        const radius = dist < 60 ? 4 : 2;
+        const radius = dist < 50 ? 1.5 : 1;
         ctx.beginPath();
         ctx.arc(n.x, n.y, radius, 0, Math.PI * 2);
-        ctx.fillStyle = '#DCFD35';
+        ctx.fillStyle = '#92CBDB';
         ctx.fill();
         for (let j = idx + 1; j < nodes.length; j++) {
           const m = nodes[j];
           const d = Math.hypot(n.x - m.x, n.y - m.y);
-          if (d < 80) {
-            ctx.strokeStyle = 'rgba(220,253,53,0.2)';
-            ctx.lineWidth = 1;
+          if (d < 100) {
+            const nearMouse =
+              mouse.active &&
+              (Math.hypot(n.x - mouse.x, n.y - mouse.y) < 80 ||
+                Math.hypot(m.x - mouse.x, m.y - mouse.y) < 80);
+            ctx.strokeStyle = nearMouse
+              ? 'rgba(146,203,219,1)'
+              : 'rgba(146,203,219,0.5)';
+            ctx.lineWidth = 0.5;
             ctx.beginPath();
             ctx.moveTo(n.x, n.y);
             ctx.lineTo(m.x, m.y);
@@ -66,9 +72,13 @@ export default function NetworkMesh() {
       mouse.x = e.clientX - rect.left;
       mouse.y = e.clientY - rect.top;
       mouse.active = true;
+      const offsetX = (mouse.x - rect.width / 2) / 20;
+      const offsetY = (mouse.y - rect.height / 2) / 20;
+      canvas.style.transform = `translate3d(${offsetX}px, ${offsetY}px, 0)`;
     };
     const handleLeave = () => {
       mouse.active = false;
+      canvas.style.transform = 'translate3d(0,0,0)';
     };
 
     canvas.addEventListener('mousemove', handleMove);
@@ -83,6 +93,6 @@ export default function NetworkMesh() {
     };
   }, []);
 
-  return <canvas ref={canvasRef} className="h-full w-full" />;
+  return <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />;
 }
 


### PR DESCRIPTION
## Summary
- revamp header with animated underline, sticky background, and mobile burger menu
- build two-column hero with dynamic network mesh
- enhance network mesh with more nodes, parallax, and hover effects

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: asks for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68b37996bbfc83248a492cc5216b8a44