### PR TITLE
feat: enhance landing visuals

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -34,7 +34,7 @@ export const dynamic = 'force-dynamic';
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const config = getLandingConfig();
   return (
-    <html lang="ru">
+    <html lang="ru" className="scroll-smooth">
       <body
         className={`${headingFont.variable} ${bodyFont.variable} ${numericFont.variable} flex min-h-screen flex-col antialiased font-body`}
       >

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -6,7 +6,7 @@ import FeatureCard from '@/components/feature-card';
 import FaqItem from '@/components/faq-item';
 import Stats from '@/components/stats';
 import { motion, useReducedMotion } from 'framer-motion';
-import { Lock, Users, Activity, Link as LinkIcon } from 'lucide-react';
+import { Lock, Users, Activity, Link as LinkIcon, Shield } from 'lucide-react';
 
 const NetworkMesh = dynamic(() => import('@/components/network-mesh'), { ssr: false });
 
@@ -28,6 +28,10 @@ export default function Home() {
     {
       icon: <LinkIcon className="feature-icon mb-2 h-6 w-6 text-bodaghee-accent" />,
       text: 'Публичные ссылки на блоки живут 24 часа и защищены CAPTCHA.',
+    },
+    {
+      icon: <Shield className="feature-icon mb-2 h-6 w-6 text-bodaghee-accent" />,
+      text: 'Содержимое шифруется на вашем устройстве. Мы храним только зашифрованные данные и технические метаданные.',
     },
   ];
 
@@ -91,7 +95,7 @@ export default function Home() {
         transition={reduceMotion ? undefined : { duration: 0.4 }}
       >
         <h2 className="mb-4 text-2xl font-semibold">Преимущества</h2>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
           {features.map((f, i) => (
             <FeatureCard key={i} icon={f.icon} text={f.text} delay={i * 0.1} />
           ))}
@@ -116,16 +120,12 @@ export default function Home() {
         transition={reduceMotion ? undefined : { duration: 0.4 }}
       >
         <h2 className="mb-4 text-2xl font-semibold">FAQ</h2>
-        <div className="max-h-64 space-y-4 overflow-y-auto rounded border border-bodaghee-accent/20 bg-bodaghee-bg p-4 text-white">
+        <div className="space-y-4">
           {faqs.map((f, i) => (
             <FaqItem key={i} question={f.q} answer={f.a} delay={i * 0.1} />
           ))}
         </div>
       </motion.section>
-
-      <p className="mx-auto mb-16 max-w-2xl px-4 text-sm text-white/70 sm:px-8">
-        Содержимое шифруется на вашем устройстве. Мы храним только зашифрованные данные и технические метаданные.
-      </p>
     </div>
   );
 }

--- a/apps/web/src/components/faq-item.tsx
+++ b/apps/web/src/components/faq-item.tsx
@@ -12,14 +12,14 @@ export default function FaqItem({ question, answer, delay = 0 }: Props) {
   const reduceMotion = useReducedMotion();
   return (
     <motion.div
-      className="card-fade rounded bg-bodaghee-bg p-4 text-white"
+      className="card-fade py-2"
       initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
       whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={reduceMotion ? undefined : { duration: 0.4, delay }}
     >
-      <h3 className="mb-2">{question}</h3>
-      <p>{answer}</p>
+      <h3 className="mb-1 text-bodaghee-accent">{question}</h3>
+      <p className="text-white">{answer}</p>
     </motion.div>
   );
 }

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -11,7 +11,7 @@ interface Links {
 
 export default function Footer({ links }: { links: Links }) {
   return (
-    <footer className="bg-bodaghee-bg text-white">
+    <footer className="bg-bodaghee-bg text-white border-t border-bodaghee-accent">
       <div className="container mx-auto grid gap-8 px-4 py-8 text-sm sm:grid-cols-2">
         <div>
           <h3 className="mb-2 font-semibold uppercase">Inquiries</h3>

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -21,12 +21,12 @@ export default function Header() {
     {
       href: "/owner",
       label: "Кабинет пользователя",
-      icon: <User className="h-4 w-4" />,
+      icon: <User className="h-4 w-4 text-bodaghee-accent" />,
     },
     {
       href: "/verifier",
       label: "Кабинет верификатора",
-      icon: <ShieldCheck className="h-4 w-4" />,
+      icon: <ShieldCheck className="h-4 w-4 text-bodaghee-accent" />,
     },
   ];
 
@@ -48,7 +48,7 @@ export default function Header() {
     >
       <Link
         href={href}
-        className="text-sm font-body uppercase text-white"
+        className="flex items-center gap-1 text-sm font-body uppercase text-white"
       >
         {icon}
         <span>{label}</span>
@@ -62,7 +62,7 @@ export default function Header() {
   );
 
   return (
-    <header className="sticky top-0 z-50 bg-bodaghee-bg/80">
+    <header className="sticky top-0 z-50 bg-bodaghee-bg/80 border-b border-bodaghee-accent">
       <nav className="container mx-auto flex items-center justify-between p-4">
         <Link href="/" className="text-xl font-bold text-white">
           Afterlight

--- a/apps/web/src/components/landing-content.tsx
+++ b/apps/web/src/components/landing-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Lock, Users, Activity, Link as LinkIcon } from "lucide-react";
+import { Lock, Users, Activity, Link as LinkIcon, Shield } from "lucide-react";
 import { motion } from "framer-motion";
 import FaqItem from "@/components/faq-item";
 
@@ -21,6 +21,10 @@ export default function LandingContent() {
     {
       icon: LinkIcon,
       text: "Публичные ссылки на блоки живут 24 часа и защищены CAPTCHA.",
+    },
+    {
+      icon: Shield,
+      text: "Содержимое шифруется на вашем устройстве. Мы храним только зашифрованные данные и технические метаданные.",
     },
   ];
 
@@ -92,17 +96,12 @@ export default function LandingContent() {
 
       <section className="mb-6">
         <h2 className="mb-4 text-2xl font-semibold">FAQ</h2>
-        <div className="max-h-64 space-y-4 overflow-y-auto rounded border border-bodaghee-accent/20 bg-bodaghee-bg p-4 text-white">
+        <div className="space-y-4">
           {faqs.map((f, i) => (
             <FaqItem key={i} question={f.q} answer={f.a} delay={i * 0.1} />
           ))}
         </div>
       </section>
-
-      <p className="text-sm text-white/70">
-        Содержимое шифруется на вашем устройстве. Мы храним только
-        зашифрованные данные и технические метаданные.
-      </p>
     </div>
   );
 }

--- a/apps/web/src/components/network-mesh.tsx
+++ b/apps/web/src/components/network-mesh.tsx
@@ -19,11 +19,11 @@ export default function NetworkMesh() {
     };
     resize();
 
-    const nodes = Array.from({ length: 50 }, () => ({
+    const nodes = Array.from({ length: 200 }, () => ({
       x: Math.random() * canvas.width,
       y: Math.random() * canvas.height,
-      vx: (Math.random() - 0.5) * 0.5,
-      vy: (Math.random() - 0.5) * 0.5,
+      vx: (Math.random() - 0.5) * 0.15,
+      vy: (Math.random() - 0.5) * 0.15,
     }));
 
     const mouse = { x: 0, y: 0, active: false };
@@ -42,20 +42,20 @@ export default function NetworkMesh() {
         const radius = dist < 50 ? 1.5 : 1;
         ctx.beginPath();
         ctx.arc(n.x, n.y, radius, 0, Math.PI * 2);
-        ctx.fillStyle = '#92CBDB';
+        ctx.fillStyle = 'rgba(146,203,219,0.8)';
         ctx.fill();
         for (let j = idx + 1; j < nodes.length; j++) {
           const m = nodes[j];
           const d = Math.hypot(n.x - m.x, n.y - m.y);
-          if (d < 100) {
+          if (d < 180) {
             const nearMouse =
               mouse.active &&
-              (Math.hypot(n.x - mouse.x, n.y - mouse.y) < 80 ||
-                Math.hypot(m.x - mouse.x, m.y - mouse.y) < 80);
+              (Math.hypot(n.x - mouse.x, n.y - mouse.y) < 100 ||
+                Math.hypot(m.x - mouse.x, m.y - mouse.y) < 100);
             ctx.strokeStyle = nearMouse
-              ? 'rgba(146,203,219,1)'
-              : 'rgba(146,203,219,0.5)';
-            ctx.lineWidth = 0.5;
+              ? 'rgba(146,203,219,0.7)'
+              : 'rgba(146,203,219,0.3)';
+            ctx.lineWidth = 0.15;
             ctx.beginPath();
             ctx.moveTo(n.x, n.y);
             ctx.lineTo(m.x, m.y);
@@ -72,13 +72,9 @@ export default function NetworkMesh() {
       mouse.x = e.clientX - rect.left;
       mouse.y = e.clientY - rect.top;
       mouse.active = true;
-      const offsetX = (mouse.x - rect.width / 2) / 20;
-      const offsetY = (mouse.y - rect.height / 2) / 20;
-      canvas.style.transform = `translate3d(${offsetX}px, ${offsetY}px, 0)`;
     };
     const handleLeave = () => {
       mouse.active = false;
-      canvas.style.transform = 'translate3d(0,0,0)';
     };
 
     canvas.addEventListener('mousemove', handleMove);


### PR DESCRIPTION
## Summary
- densify and smooth the landing mesh animation
- restyle FAQ section with on-page colored Q/A and smooth scrolling
- add fifth encryption benefit and separate header/footer with borders
- scale back mesh nodes and line density for a lighter effect
- expand mesh with thinner, dimmer lines and remove cursor-driven shifts
- brighten header/footer dividers and align cabinet icons with accent color

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(blocked: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b37f1591dc8324a41ffb3e30f29c6f