### PR TITLE
Refine landing network mesh

### DIFF
--- a/apps/web/src/components/network-mesh.tsx
+++ b/apps/web/src/components/network-mesh.tsx
@@ -19,14 +19,14 @@ export default function NetworkMesh() {
     };
     resize();
 
-    const nodes = Array.from({ length: 200 }, () => ({
+    const nodes = Array.from({ length: 120 }, () => ({
       x: Math.random() * canvas.width,
       y: Math.random() * canvas.height,
       vx: (Math.random() - 0.5) * 0.2,
       vy: (Math.random() - 0.5) * 0.2,
     }));
 
-    const mouse = { x: 0, y: 0, active: false };
+    let hovered: number | null = null;
 
     let frame: number;
     const draw = () => {
@@ -38,24 +38,20 @@ export default function NetworkMesh() {
           if (n.x < 0 || n.x > canvas.width) n.vx *= -1;
           if (n.y < 0 || n.y > canvas.height) n.vy *= -1;
         }
-        const dist = mouse.active ? Math.hypot(n.x - mouse.x, n.y - mouse.y) : Infinity;
-        const radius = dist < 60 ? 1.2 : 0.8;
+        const radius = hovered === idx ? 1.5 : 0.8;
         ctx.beginPath();
         ctx.arc(n.x, n.y, radius, 0, Math.PI * 2);
-        ctx.fillStyle = 'rgba(146,203,219,0.8)';
+        ctx.fillStyle = hovered === idx ? 'rgba(146,203,219,0.4)' : 'rgba(146,203,219,0.2)';
         ctx.fill();
         for (let j = idx + 1; j < nodes.length; j++) {
           const m = nodes[j];
           const d = Math.hypot(n.x - m.x, n.y - m.y);
-          if (d < 150) {
-            const nearMouse =
-              mouse.active &&
-              (Math.hypot(n.x - mouse.x, n.y - mouse.y) < 100 ||
-                Math.hypot(m.x - mouse.x, m.y - mouse.y) < 100);
-            ctx.strokeStyle = nearMouse
-              ? 'rgba(146,203,219,1)'
-              : 'rgba(146,203,219,0.5)';
-            ctx.lineWidth = 0.3;
+          if (d < 120) {
+            const highlight = hovered !== null && (idx === hovered || j === hovered);
+            ctx.strokeStyle = highlight
+              ? 'rgba(146,203,219,0.4)'
+              : 'rgba(146,203,219,0.2)';
+            ctx.lineWidth = highlight ? 0.8 : 0.4;
             ctx.beginPath();
             ctx.moveTo(n.x, n.y);
             ctx.lineTo(m.x, m.y);
@@ -63,18 +59,42 @@ export default function NetworkMesh() {
           }
         }
       });
+      ctx.save();
+      ctx.globalCompositeOperation = 'destination-in';
+      const fade = ctx.createRadialGradient(
+        canvas.width / 2,
+        canvas.height / 2,
+        0,
+        canvas.width / 2,
+        canvas.height / 2,
+        Math.max(canvas.width, canvas.height) / 2
+      );
+      fade.addColorStop(0.7, 'rgba(0,0,0,1)');
+      fade.addColorStop(1, 'rgba(0,0,0,0)');
+      ctx.fillStyle = fade;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.restore();
       frame = requestAnimationFrame(draw);
     };
     draw();
 
     const handleMove = (e: MouseEvent) => {
       const rect = canvas.getBoundingClientRect();
-      mouse.x = e.clientX - rect.left;
-      mouse.y = e.clientY - rect.top;
-      mouse.active = true;
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      let nearest: number | null = null;
+      let minDist = Infinity;
+      nodes.forEach((n, i) => {
+        const dist = Math.hypot(n.x - x, n.y - y);
+        if (dist < 10 && dist < minDist) {
+          minDist = dist;
+          nearest = i;
+        }
+      });
+      hovered = nearest;
     };
     const handleLeave = () => {
-      mouse.active = false;
+      hovered = null;
     };
 
     canvas.addEventListener('mousemove', handleMove);
@@ -89,6 +109,6 @@ export default function NetworkMesh() {
     };
   }, []);
 
-  return <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />;
+  return <canvas ref={canvasRef} className="absolute inset-0 h-full w-full opacity-60" />;
 }
 


### PR DESCRIPTION
## Summary
- Tone down landing page network mesh
- Highlight only hovered nodes and fade mesh edges

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b408c3b80083248c06a674c1083304