### PR TITLE
feat: add login modal and password recovery

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4702,7 +4702,13 @@
       "RegisterDto": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string"
+          },
           "email": {
+            "type": "string"
+          },
+          "phone": {
             "type": "string"
           },
           "password": {
@@ -4718,8 +4724,9 @@
           }
         },
         "required": [
+          "name",
           "email",
-          "password"
+          "phone"
         ]
       },
       "LoginDto": {

--- a/apps/api/prisma/migrations/20250901000000_add_user_name/migration.sql
+++ b/apps/api/prisma/migrations/20250901000000_add_user_name/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN "name" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -94,6 +94,7 @@ enum UserRole {
 model User {
   id           String   @id @default(uuid()) @map("id") @db.Uuid
   email        String   @unique
+  name         String?  @map("name")
   phone        String?
   passwordHash String?  @map("password_hash")
   passkeyPub   String?  @map("passkey_pub")

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -25,7 +25,13 @@ export class AuthController {
 
   @Post('register')
   async register(@Body() dto: RegisterDto) {
-    const user = await this.auth.register(dto.email, dto.password, dto.role);
+    const user = await this.auth.register(
+      dto.name,
+      dto.email,
+      dto.phone,
+      dto.password,
+      dto.role,
+    );
     const { id, email, role } = user;
     return { id, email, role };
   }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -24,14 +24,17 @@ export class AuthService {
   }
 
   async register(
+    name: string,
     email: string,
-    password: string,
+    phone: string,
+    password?: string,
     role: UserRole = UserRole.Owner,
   ): Promise<User> {
-    const passwordHash = await hashPassword(password);
-    return this.prisma.user.create({
-      data: { email, passwordHash, role },
-    });
+    const data: any = { name, email, phone, role };
+    if (password) {
+      data.passwordHash = await hashPassword(password);
+    }
+    return this.prisma.user.create({ data });
   }
 
   async validateUser(email: string, password: string): Promise<User | null> {

--- a/apps/api/src/auth/dto/register.dto.ts
+++ b/apps/api/src/auth/dto/register.dto.ts
@@ -4,12 +4,21 @@ import { UserRole } from '@prisma/client';
 
 export class RegisterDto {
   @ApiProperty()
+  @IsString()
+  name!: string;
+
+  @ApiProperty()
   @IsEmail()
   email!: string;
 
   @ApiProperty()
   @IsString()
-  password!: string;
+  phone!: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  password?: string;
 
   @ApiProperty({ required: false, enum: UserRole })
   @IsOptional()

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -151,8 +151,10 @@ export interface components {
       error?: string;
     };
     RegisterDto: {
+      name: string;
       email: string;
-      password: string;
+      phone: string;
+      password?: string;
       /** @enum {string} */
       role?: "Owner" | "Verifier" | "Admin";
     };

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import dynamic from 'next/dynamic';
-import Link from 'next/link';
 import FeatureCard from '@/components/feature-card';
 import FaqItem from '@/components/faq-item';
 import Stats from '@/components/stats';
@@ -75,12 +74,7 @@ export default function Home() {
         <div className="flex flex-col items-center text-center md:items-start md:text-left">
           <h1 className="mb-4 text-[86px] font-heading text-white">Afterlight</h1>
           <p className="mb-6 text-xl text-bodaghee-accent">Цифровое завещание</p>
-          <Link
-            href="/register"
-            className="inline-block border border-bodaghee-accent px-6 py-3 text-bodaghee-accent transition-colors hover:bg-bodaghee-accent hover:text-bodaghee-bg"
-          >
-            Создать сейф
-          </Link>
+          
         </div>
         <div className="relative h-96 w-full md:h-[650px]">
           <ParticlesBackground />

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -3,7 +3,7 @@
 import { useState, type ReactNode } from "react";
 import Link from "next/link";
 import { useAuth } from "@/shared/auth/useAuth";
-import { LogIn, LogOut, Menu, X } from "lucide-react";
+import { LogIn, LogOut, Menu, User, X } from "lucide-react";
 import { motion } from "framer-motion";
 import LoginModal from "@/components/login-modal";
 import { httpClient } from "@/shared/api/httpClient";
@@ -13,7 +13,13 @@ export default function Header() {
   const [open, setOpen] = useState(false);
   const [loginOpen, setLoginOpen] = useState(false);
 
-  const mainLinks: { href: string; label: string; icon: ReactNode }[] = [];
+  const mainLinks: { href: string; label: string; icon: ReactNode }[] = [
+    {
+      href: "/cabinet",
+      label: "Личный кабинет",
+      icon: <User className="h-4 w-4" />,
+    },
+  ];
 
   const authLinks =
     role === "guest"

--- a/apps/web/src/components/login-modal.tsx
+++ b/apps/web/src/components/login-modal.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useEffect, useState } from "react";
 import { httpClient } from "@/shared/api/httpClient";
+import { useAuth } from "@/shared/auth/useAuth";
 import { X } from "lucide-react";
 
 interface LoginModalProps {
@@ -10,56 +11,24 @@ interface LoginModalProps {
 }
 
 export default function LoginModal({ open, onClose }: LoginModalProps) {
-  const [mode, setMode] = useState<"register" | "login" | "forgot">("register");
-  const [name, setName] = useState("");
+  const { login: authLogin } = useAuth();
+  const [mode, setMode] = useState<"login" | "forgot">("login");
   const [email, setEmail] = useState("");
-  const [phone, setPhone] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
 
   useEffect(() => {
     if (open) {
-      setMode("register");
+      setMode("login");
       setError("");
       setMessage("");
+      setEmail("");
+      setPassword("");
     }
   }, [open]);
 
   if (!open) return null;
-
-  function formatPhone(value: string) {
-    const digits = value.replace(/\D/g, "").slice(0, 10);
-    const parts = [] as string[];
-    if (digits.length > 0) parts.push(digits.slice(0, 3));
-    if (digits.length > 3) parts.push(digits.slice(3, 6));
-    if (digits.length > 6) parts.push(digits.slice(6, 8));
-    if (digits.length > 8) parts.push(digits.slice(8, 10));
-    let result = "+7";
-    if (parts[0]) result += " " + parts[0];
-    if (parts[1]) result += " " + parts[1];
-    if (parts[2]) result += "-" + parts[2];
-    if (parts[3]) result += "-" + parts[3];
-    return result;
-  }
-
-  async function handleRegister(e: FormEvent) {
-    e.preventDefault();
-    setError("");
-    try {
-      const res = await httpClient("/auth/register", {
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, email, phone }),
-      });
-      if (!res.ok) {
-        setError("Ошибка регистрации");
-        return;
-      }
-      onClose();
-    } catch {
-      setError("Ошибка соединения");
-    }
-  }
 
   async function handleLogin(e: FormEvent) {
     e.preventDefault();
@@ -72,6 +41,10 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
       if (!res.ok) {
         setError("Ошибка логина");
         return;
+      }
+      const data = await res.json().catch(() => ({}));
+      if (data?.role) {
+        authLogin(data.role.toLowerCase());
       }
       onClose();
     } catch {
@@ -112,47 +85,6 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
         >
           <X className="h-6 w-6" />
         </button>
-        {mode === "register" && (
-          <form onSubmit={handleRegister} className="flex flex-col gap-4 font-body">
-            <input
-              type="text"
-              placeholder="Имя пользователя"
-              value={name}
-              onChange={(e) =>
-                setName(e.target.value.replace(/[^\p{L}\s]/gu, ""))
-              }
-              className="rounded border border-bodaghee-accent bg-bodaghee-bg p-2 text-white placeholder:text-white/50"
-            />
-            <input
-              type="email"
-              placeholder="Email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="rounded border border-bodaghee-accent bg-bodaghee-bg p-2 text-white placeholder:text-white/50"
-            />
-            <input
-              type="tel"
-              placeholder="+7 999 999-99-99"
-              value={phone}
-              onChange={(e) => setPhone(formatPhone(e.target.value))}
-              className="rounded border border-bodaghee-accent bg-bodaghee-bg p-2 text-white placeholder:text-white/50"
-            />
-            {error && <p className="text-bodaghee-accent">{error}</p>}
-            <button
-              type="submit"
-              className="rounded border border-bodaghee-accent bg-bodaghee-bg px-4 py-2 text-white transition-colors hover:bg-bodaghee-accent hover:text-bodaghee-bg"
-            >
-              Зарегистрироваться
-            </button>
-            <button
-              type="button"
-              onClick={() => setMode("login")}
-              className="text-sm text-bodaghee-accent underline"
-            >
-              У меня есть пароль
-            </button>
-          </form>
-        )}
         {mode === "login" && (
           <form onSubmit={handleLogin} className="flex flex-col gap-4 font-body">
             <input
@@ -185,13 +117,6 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
                 Восстановить пароль
               </button>
             </div>
-            <button
-              type="button"
-              onClick={() => setMode("register")}
-              className="text-sm text-bodaghee-accent underline"
-            >
-              Нет аккаунта?
-            </button>
           </form>
         )}
         {mode === "forgot" && (

--- a/apps/web/src/components/login-modal.tsx
+++ b/apps/web/src/components/login-modal.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { httpClient } from "@/shared/api/httpClient";
+import { X } from "lucide-react";
 
 interface LoginModalProps {
   open: boolean;
@@ -9,13 +10,56 @@ interface LoginModalProps {
 }
 
 export default function LoginModal({ open, onClose }: LoginModalProps) {
+  const [mode, setMode] = useState<"register" | "login" | "forgot">("register");
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
-  const [mode, setMode] = useState<"login" | "forgot">("login");
   const [message, setMessage] = useState("");
 
+  useEffect(() => {
+    if (open) {
+      setMode("register");
+      setError("");
+      setMessage("");
+    }
+  }, [open]);
+
   if (!open) return null;
+
+  function formatPhone(value: string) {
+    const digits = value.replace(/\D/g, "").slice(0, 10);
+    const parts = [] as string[];
+    if (digits.length > 0) parts.push(digits.slice(0, 3));
+    if (digits.length > 3) parts.push(digits.slice(3, 6));
+    if (digits.length > 6) parts.push(digits.slice(6, 8));
+    if (digits.length > 8) parts.push(digits.slice(8, 10));
+    let result = "+7";
+    if (parts[0]) result += " " + parts[0];
+    if (parts[1]) result += " " + parts[1];
+    if (parts[2]) result += "-" + parts[2];
+    if (parts[3]) result += "-" + parts[3];
+    return result;
+  }
+
+  async function handleRegister(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+    try {
+      const res = await httpClient("/auth/register", {
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email, phone }),
+      });
+      if (!res.ok) {
+        setError("Ошибка регистрации");
+        return;
+      }
+      onClose();
+    } catch {
+      setError("Ошибка соединения");
+    }
+  }
 
   async function handleLogin(e: FormEvent) {
     e.preventDefault();
@@ -52,9 +96,64 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="w-full max-w-sm rounded bg-bodaghee-bg p-6">
-        {mode === "login" ? (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-sm rounded border-2 border-bodaghee-accent bg-bodaghee-bg p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Закрыть"
+          className="absolute right-2 top-2 text-bodaghee-accent"
+        >
+          <X className="h-6 w-6" />
+        </button>
+        {mode === "register" && (
+          <form onSubmit={handleRegister} className="flex flex-col gap-4 font-body">
+            <input
+              type="text"
+              placeholder="Имя пользователя"
+              value={name}
+              onChange={(e) =>
+                setName(e.target.value.replace(/[^\p{L}\s]/gu, ""))
+              }
+              className="rounded border border-bodaghee-accent bg-bodaghee-bg p-2 text-white placeholder:text-white/50"
+            />
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="rounded border border-bodaghee-accent bg-bodaghee-bg p-2 text-white placeholder:text-white/50"
+            />
+            <input
+              type="tel"
+              placeholder="+7 999 999-99-99"
+              value={phone}
+              onChange={(e) => setPhone(formatPhone(e.target.value))}
+              className="rounded border border-bodaghee-accent bg-bodaghee-bg p-2 text-white placeholder:text-white/50"
+            />
+            {error && <p className="text-bodaghee-accent">{error}</p>}
+            <button
+              type="submit"
+              className="rounded border border-bodaghee-accent bg-bodaghee-bg px-4 py-2 text-white transition-colors hover:bg-bodaghee-accent hover:text-bodaghee-bg"
+            >
+              Зарегистрироваться
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode("login")}
+              className="text-sm text-bodaghee-accent underline"
+            >
+              У меня есть пароль
+            </button>
+          </form>
+        )}
+        {mode === "login" && (
           <form onSubmit={handleLogin} className="flex flex-col gap-4 font-body">
             <input
               type="email"
@@ -71,21 +170,31 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
               className="rounded border border-bodaghee-accent bg-bodaghee-bg p-2 text-white placeholder:text-white/50"
             />
             {error && <p className="text-bodaghee-accent">{error}</p>}
-            <button
-              type="submit"
-              className="rounded border border-bodaghee-accent bg-bodaghee-bg px-4 py-2 text-white transition-colors hover:bg-bodaghee-accent hover:text-bodaghee-bg"
-            >
-              Войти
-            </button>
+            <div className="flex items-center gap-4">
+              <button
+                type="submit"
+                className="rounded border border-bodaghee-accent bg-bodaghee-bg px-4 py-2 text-white transition-colors hover:bg-bodaghee-accent hover:text-bodaghee-bg"
+              >
+                Войти
+              </button>
+              <button
+                type="button"
+                onClick={() => setMode("forgot")}
+                className="text-sm text-bodaghee-accent underline"
+              >
+                Восстановить пароль
+              </button>
+            </div>
             <button
               type="button"
-              onClick={() => setMode("forgot")}
+              onClick={() => setMode("register")}
               className="text-sm text-bodaghee-accent underline"
             >
-              Восстановить пароль
+              Нет аккаунта?
             </button>
           </form>
-        ) : (
+        )}
+        {mode === "forgot" && (
           <form onSubmit={handleForgot} className="flex flex-col gap-4 font-body">
             <input
               type="email"

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -166,11 +166,13 @@ paths:
           application/json:
             schema:
               type: object
-              required: [email, password]
+              required: [name, email, phone]
               properties:
+                name: { type: string }
                 email: { type: string }
+                phone: { type: string }
                 password: { type: string }
-                role: { type: string, enum: [User, Admin] }
+                role: { type: string, enum: [Owner, Verifier, Admin] }
       responses:
         '201':
           description: Created


### PR DESCRIPTION
## Summary
- add unified auth modal with registration (name, email, phone) and login
- update API register endpoint to store user name/phone and support optional password
- drop standalone register route and link from homepage

## Testing
- `npx prisma generate --schema=apps/api/prisma/schema.prisma`
- `npm test` (apps/api)
- `npm run lint` (apps/web) *(fails: interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b4076443c48324ac31615373f5ca7b