### PR TITLE
feat: add registration flow and refresh auth modal

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -17,7 +17,8 @@
         "react": "18.3.1",
         "react-countup": "^6.5.3",
         "react-dom": "18.3.1",
-        "react-icons": "^4.12.0"
+        "react-icons": "^4.12.0",
+        "react-input-mask": "^2.0.4"
       },
       "devDependencies": {
         "@types/node": "^20.14.10",
@@ -1019,6 +1020,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1716,6 +1726,20 @@
         "react": "*"
       }
     },
+    "node_modules/react-input-mask": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
+      "integrity": "sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0",
+        "react-dom": ">=0.14.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -2227,6 +2251,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,8 @@
     "react": "18.3.1",
     "react-countup": "^6.5.3",
     "react-dom": "18.3.1",
-    "react-icons": "^4.12.0"
+    "react-icons": "^4.12.0",
+    "react-input-mask": "^2.0.4"
   },
   "devDependencies": {
     "@types/node": "^20.14.10",

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -3,7 +3,7 @@
 import { useState, type ReactNode } from "react";
 import Link from "next/link";
 import { useAuth } from "@/shared/auth/useAuth";
-import { LogIn, LogOut, Menu, User, X } from "lucide-react";
+import { LogIn, LogOut, Menu, X } from "lucide-react";
 import { motion } from "framer-motion";
 import LoginModal from "@/components/login-modal";
 import { httpClient } from "@/shared/api/httpClient";
@@ -13,19 +13,13 @@ export default function Header() {
   const [open, setOpen] = useState(false);
   const [loginOpen, setLoginOpen] = useState(false);
 
-  const mainLinks: { href: string; label: string; icon: ReactNode }[] = [
-    {
-      href: "/cabinet",
-      label: "Личный кабинет",
-      icon: <User className="h-4 w-4" />,
-    },
-  ];
+  const mainLinks: { href: string; label: string; icon: ReactNode }[] = [];
 
   const authLinks =
     role === "guest"
       ? [
           {
-            label: "Войти",
+            label: "Вход/Регистрация",
             icon: <LogIn className="h-4 w-4" />,
             onClick: () => setLoginOpen(true),
           },


### PR DESCRIPTION
## Summary
- remove broken cabinet link and rename auth button to 'Вход/Регистрация'
- refresh login modal UI with registration, phone mask, and better layout
- add react-input-mask dependency

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b42ce170e883249fcea437fb515fec