### PR TITLE
fix(web): add react-input-mask types

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -24,6 +24,7 @@
         "@types/node": "^20.14.10",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@types/react-input-mask": "^3.0.6",
         "autoprefixer": "^10.4.20",
         "openapi-typescript": "^6.5.4",
         "postcss": "^8.4.41",
@@ -443,6 +444,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-input-mask": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-input-mask/-/react-input-mask-3.0.6.tgz",
+      "integrity": "sha512-+5I18WKyG3eWIj7TVPWfK1VitI9mPpS9y6jE/BfmTCe+iL27NfBw/yzKRvCFp1DRBvlvvcsiZf05bub0YC1k8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/ansi-colors": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "@types/node": "^20.14.10",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/react-input-mask": "^3.0.6",
     "autoprefixer": "^10.4.20",
     "openapi-typescript": "^6.5.4",
     "postcss": "^8.4.41",


### PR DESCRIPTION
## Summary
- add @types/react-input-mask to resolve missing type declarations

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b430c996fc83248bed90538c3c12ba