### PR TITLE
Improve mobile landing layout

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,14 +4,13 @@ import { useEffect, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import FeatureCard from '@/components/feature-card';
 import FaqItem from '@/components/faq-item';
-import Stats from '@/components/stats';
 import {
   motion,
   useReducedMotion,
   useMotionValue,
   useSpring,
 } from 'framer-motion';
-import { Lock, Users, Activity, Link as LinkIcon, Shield } from 'lucide-react';
+import { Lock, Users, Activity, Link as LinkIcon } from 'lucide-react';
 
 const ParticlesBackground = dynamic(() => import('../components/particles-background'), { ssr: false });
 
@@ -38,32 +37,25 @@ export default function Home() {
   }, [reduceMotion, x, y]);
   const features = [
     {
-      icon: <Lock className="feature-icon mb-2 h-6 w-6 text-bodaghee-accent" />,
-      text: 'Клиентское шифрование: мы не видим содержимое ваших сейфов.',
+      icon: <Lock className="h-6 w-6" />,
+      title: 'Клиентское шифрование',
+      text: 'Содержимое шифруется на вашем устройстве. Мы храним только зашифрованные данные.',
     },
     {
-      icon: <Users className="feature-icon mb-2 h-6 w-6 text-bodaghee-accent" />,
-      text: 'Кворум 2 из 3 верификаторов подтверждает событие.',
+      icon: <Users className="h-6 w-6" />,
+      title: 'Кворум 2/3',
+      text: 'Двое из трёх доверенных людей подтверждают событие.',
     },
     {
-      icon: <Activity className="feature-icon mb-2 h-6 w-6 text-bodaghee-accent" />,
-      text: 'Heartbeat: год без входа запускает процесс вручения.',
+      icon: <Activity className="h-6 w-6" />,
+      title: 'Heartbeat 365 дней',
+      text: 'Год без входа запускает процесс вручения.',
     },
     {
-      icon: <LinkIcon className="feature-icon mb-2 h-6 w-6 text-bodaghee-accent" />,
-      text: 'Публичные ссылки на блоки живут 24 часа и защищены CAPTCHA.',
+      icon: <LinkIcon className="h-6 w-6" />,
+      title: '24 часа на доступ',
+      text: 'Публичные ссылки и grace-период действуют сутки.',
     },
-    {
-      icon: <Shield className="feature-icon mb-2 h-6 w-6 text-bodaghee-accent" />,
-      text: 'Содержимое шифруется на вашем устройстве. Мы храним только зашифрованные данные и технические метаданные.',
-    },
-  ];
-
-  const stats = [
-    { value: 2, suffix: '/3', label: 'кворум' },
-    { value: 365, suffix: ' дней', label: 'heartbeat' },
-    { value: 24, suffix: ' часа', label: 'grace-период' },
-    { value: 24, suffix: ' часа', label: 'жизнь ссылки' },
   ];
 
   const faqs = [
@@ -95,57 +87,47 @@ export default function Home() {
 
   return (
     <div className="flex flex-col">
-      <section className="container mx-auto grid items-center gap-8 px-4 py-16 sm:px-8 md:grid-cols-2">
+      <section className="container mx-auto grid items-center gap-6 px-4 py-12 sm:px-8 md:grid-cols-2">
         <div className="flex flex-col items-center text-center md:items-start md:text-left">
           <motion.h1
             ref={headingRef}
             style={reduceMotion ? undefined : { x: springX, y: springY }}
-            className="mb-4 text-[120px] font-heading text-white"
+            className="mb-4 text-5xl font-heading text-white sm:text-7xl md:text-[120px]"
           >
             Afterlight
           </motion.h1>
-          <p className="mb-6 text-xl text-bodaghee-accent">Цифровое завещание</p>
-          
+          <p className="mb-4 text-lg text-bodaghee-accent">Цифровое завещание</p>
+
         </div>
-        <div className="relative h-96 w-full md:h-[650px]">
+        <div className="relative h-64 w-full md:h-[650px]">
           <ParticlesBackground />
         </div>
       </section>
 
       <motion.section
-        className="container mx-auto px-4 py-16 sm:px-8"
+        className="container mx-auto px-4 py-12 sm:px-8"
         initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
         whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
         viewport={{ once: true }}
         transition={reduceMotion ? undefined : { duration: 0.4 }}
       >
         <h2 className="mb-4 text-2xl font-semibold">Преимущества</h2>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {features.map((f, i) => (
-            <FeatureCard key={i} icon={f.icon} text={f.text} delay={i * 0.1} />
+            <FeatureCard key={i} icon={f.icon} title={f.title} text={f.text} delay={i * 0.1} />
           ))}
         </div>
       </motion.section>
 
       <motion.section
-        className="container mx-auto px-4 py-16 sm:px-8"
-        initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
-        whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
-        viewport={{ once: true }}
-        transition={reduceMotion ? undefined : { duration: 0.4 }}
-      >
-        <Stats items={stats} />
-      </motion.section>
-
-      <motion.section
-        className="container mx-auto px-4 py-16 sm:px-8"
+        className="container mx-auto px-4 py-12 sm:px-8"
         initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
         whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
         viewport={{ once: true }}
         transition={reduceMotion ? undefined : { duration: 0.4 }}
       >
         <h2 className="mb-4 text-2xl font-semibold">FAQ</h2>
-        <div className="space-y-4">
+        <div className="space-y-2">
           {faqs.map((f, i) => (
             <FaqItem key={i} question={f.q} answer={f.a} delay={i * 0.1} />
           ))}

--- a/apps/web/src/components/faq-item.tsx
+++ b/apps/web/src/components/faq-item.tsx
@@ -11,15 +11,15 @@ interface Props {
 export default function FaqItem({ question, answer, delay = 0 }: Props) {
   const reduceMotion = useReducedMotion();
   return (
-    <motion.div
+    <motion.details
       className="card-fade py-2"
       initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
       whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={reduceMotion ? undefined : { duration: 0.4, delay }}
     >
-      <h3 className="mb-1 text-bodaghee-accent">{question}</h3>
-      <p className="text-white">{answer}</p>
-    </motion.div>
+      <summary className="cursor-pointer text-bodaghee-accent">{question}</summary>
+      <p className="mt-1 text-white">{answer}</p>
+    </motion.details>
   );
 }

--- a/apps/web/src/components/feature-card.tsx
+++ b/apps/web/src/components/feature-card.tsx
@@ -5,11 +5,12 @@ import type { ReactNode } from 'react';
 
 interface Props {
   icon: ReactNode;
+  title: string;
   text: string;
   delay?: number;
 }
 
-export default function FeatureCard({ icon, text, delay = 0 }: Props) {
+export default function FeatureCard({ icon, title, text, delay = 0 }: Props) {
   const reduceMotion = useReducedMotion();
   return (
     <motion.div
@@ -20,7 +21,8 @@ export default function FeatureCard({ icon, text, delay = 0 }: Props) {
       transition={reduceMotion ? undefined : { duration: 0.4, delay }}
     >
       <div className="feature-icon mb-2 text-bodaghee-accent group-hover:scale-110">{icon}</div>
-      <p className="text-sm">{text}</p>
+      <h3 className="mb-1 font-semibold text-white">{title}</h3>
+      <p className="text-sm text-white">{text}</p>
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- Make landing hero and features responsive and more compact
- Merge duplicate feature and stats blocks, trim FAQ spacing
- Collapse FAQ items for easier mobile browsing

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4349ef9a08324ace85f6687d1af09