### PR TITLE
feat: brighten particle grid and refine benefits

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -39,22 +39,22 @@ export default function Home() {
     {
       icon: <Lock className="h-6 w-6" />,
       title: 'Клиентское шифрование',
-      text: 'Содержимое шифруется на вашем устройстве. Мы храним только зашифрованные данные.',
+      text: 'Данные шифруются на устройстве.',
     },
     {
       icon: <Users className="h-6 w-6" />,
       title: 'Кворум 2/3',
-      text: 'Двое из трёх доверенных людей подтверждают событие.',
+      text: 'Двое из трёх подтверждают событие.',
     },
     {
       icon: <Activity className="h-6 w-6" />,
       title: 'Heartbeat 365 дней',
-      text: 'Год без входа запускает процесс вручения.',
+      text: 'Год без входа запускает вручение.',
     },
     {
       icon: <LinkIcon className="h-6 w-6" />,
       title: '24 часа на доступ',
-      text: 'Публичные ссылки и grace-период действуют сутки.',
+      text: 'Публичные ссылки живут сутки.',
     },
   ];
 
@@ -108,11 +108,16 @@ export default function Home() {
         className="container mx-auto px-4 py-12 sm:px-8"
         initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
         whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
-        viewport={{ once: true }}
-        transition={reduceMotion ? undefined : { duration: 0.4 }}
-      >
+      viewport={{ once: true }}
+      transition={reduceMotion ? undefined : { duration: 0.4 }}
+    >
+        <p className="mb-4 text-lg">
+          Afterlight помогает заранее упорядочить доступы, инструкции и файлы в
+          «сейфах», назначить получателей и верификаторов и раскрывать
+          информацию только при наступлении заданных событий.
+        </p>
         <h2 className="mb-4 text-2xl font-semibold">Преимущества</h2>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
           {features.map((f, i) => (
             <FeatureCard key={i} icon={f.icon} title={f.title} text={f.text} delay={i * 0.1} />
           ))}

--- a/apps/web/src/components/feature-card.tsx
+++ b/apps/web/src/components/feature-card.tsx
@@ -14,15 +14,15 @@ export default function FeatureCard({ icon, title, text, delay = 0 }: Props) {
   const reduceMotion = useReducedMotion();
   return (
     <motion.div
-      className="card-fade group rounded border border-bodaghee-accent/20 bg-bodaghee-bg p-4 text-white hover:border-bodaghee-accent"
+      className="card-fade group rounded border border-bodaghee-accent/20 bg-bodaghee-bg p-3 text-white hover:border-bodaghee-accent"
       initial={reduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }}
       whileInView={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={reduceMotion ? undefined : { duration: 0.4, delay }}
     >
-      <div className="feature-icon mb-2 text-bodaghee-accent group-hover:scale-110">{icon}</div>
-      <h3 className="mb-1 font-semibold text-white">{title}</h3>
-      <p className="text-sm text-white">{text}</p>
+      <div className="feature-icon mb-1 text-bodaghee-accent group-hover:scale-110">{icon}</div>
+      <h3 className="mb-0.5 font-semibold text-white">{title}</h3>
+      <p className="text-xs text-white">{text}</p>
     </motion.div>
   );
 }

--- a/apps/web/src/components/particles-background.tsx
+++ b/apps/web/src/components/particles-background.tsx
@@ -19,15 +19,15 @@ export default function ParticlesBackground() {
     const config = {
       particles: {
         number: { value: 100 },
-        color: { value: '#92CBDB' },
-        opacity: { value: 0.4 },
-        size: { value: 2, random: true },
+        color: { value: '#ffffff' },
+        opacity: { value: 0.9 },
+        size: { value: 3, random: true },
         line_linked: {
           enable: true,
           distance: 120,
-          color: '#92CBDB',
-          opacity: 0.2,
-          width: 1,
+          color: '#ffffff',
+          opacity: 0.8,
+          width: 2,
         },
         move: {
           enable: true,
@@ -40,7 +40,7 @@ export default function ParticlesBackground() {
           resize: true,
         },
         modes: {
-          grab: { distance: 150, line_linked: { opacity: 0.4, color: '#92CBDB' } },
+          grab: { distance: 150, line_linked: { opacity: 0.8, color: '#ffffff' } },
         },
       },
       retina_detect: true,


### PR DESCRIPTION
## Summary
- brighten particle grid with bold white lines and vivid nodes
- describe Afterlight's purpose before benefits block
- condense benefit cards for a tighter layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint config)*
- `npm run build` *(fails: Can't resolve 'react-input-mask')*


------
https://chatgpt.com/codex/tasks/task_e_68b43876014483248fc23fe5cdb6d938