### PR TITLE
feat: restyle login modal

### DIFF
--- a/apps/web/src/components/login-modal.tsx
+++ b/apps/web/src/components/login-modal.tsx
@@ -13,23 +13,36 @@ interface LoginModalProps {
 
 export default function LoginModal({ open, onClose }: LoginModalProps) {
   const { login: authLogin } = useAuth();
-  const [mode, setMode] = useState<"login" | "forgot" | "register">("login");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [name, setName] = useState("");
-  const [phone, setPhone] = useState("");
-  const [error, setError] = useState("");
+  const [mode, setMode] = useState<"main" | "forgot">("main");
+
+  const [loginEmail, setLoginEmail] = useState("");
+  const [loginPassword, setLoginPassword] = useState("");
+  const [loginError, setLoginError] = useState("");
+
+  const [regName, setRegName] = useState("");
+  const [regEmail, setRegEmail] = useState("");
+  const [regPhone, setRegPhone] = useState("");
+  const [regPassword, setRegPassword] = useState("");
+  const [regError, setRegError] = useState("");
+
+  const [forgotEmail, setForgotEmail] = useState("");
   const [message, setMessage] = useState("");
 
   useEffect(() => {
     if (open) {
-      setMode("login");
-      setError("");
+      setMode("main");
+      setLoginEmail("");
+      setLoginPassword("");
+      setLoginError("");
+
+      setRegName("");
+      setRegEmail("");
+      setRegPhone("");
+      setRegPassword("");
+      setRegError("");
+
+      setForgotEmail("");
       setMessage("");
-      setEmail("");
-      setPassword("");
-      setName("");
-      setPhone("");
     }
   }, [open]);
 
@@ -37,14 +50,14 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
 
   async function handleLogin(e: FormEvent) {
     e.preventDefault();
-    setError("");
+    setLoginError("");
     try {
       const res = await httpClient("/auth/login", {
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ email: loginEmail, password: loginPassword }),
       });
       if (!res.ok) {
-        setError("Ошибка логина");
+        setLoginError("Ошибка логина");
         return;
       }
       const data = await res.json().catch(() => ({}));
@@ -53,7 +66,7 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
       }
       onClose();
     } catch {
-      setError("Ошибка соединения");
+      setLoginError("Ошибка соединения");
     }
   }
 
@@ -63,7 +76,7 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
     try {
       const res = await httpClient("/auth/forgot-password", {
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email: forgotEmail }),
       });
       if (res.ok) {
         setMessage("Письмо отправлено");
@@ -75,19 +88,24 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
 
   async function handleRegister(e: FormEvent) {
     e.preventDefault();
-    setError("");
+    setRegError("");
     try {
       const res = await httpClient("/auth/register", {
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, email, phone, password }),
+        body: JSON.stringify({
+          name: regName,
+          email: regEmail,
+          phone: regPhone,
+          password: regPassword,
+        }),
       });
       if (!res.ok) {
-        setError("Ошибка регистрации");
+        setRegError("Ошибка регистрации");
         return;
       }
       const loginRes = await httpClient("/auth/login", {
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ email: regEmail, password: regPassword }),
       });
       if (loginRes.ok) {
         const data = await loginRes.json().catch(() => ({}));
@@ -97,7 +115,7 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
         onClose();
       }
     } catch {
-      setError("Ошибка соединения");
+      setRegError("Ошибка соединения");
     }
   }
 
@@ -107,7 +125,7 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
       onClick={onClose}
     >
       <div
-        className="relative w-full max-w-sm rounded-lg border border-bodaghee-accent bg-bodaghee-bg p-8 pt-10 shadow-lg"
+        className="relative w-full max-w-3xl rounded-xl border border-bodaghee-accent bg-gradient-to-br from-bodaghee-bg to-bodaghee-bg/80 p-8 pt-12 shadow-lg"
         onClick={(e) => e.stopPropagation()}
       >
         <button
@@ -118,122 +136,122 @@ export default function LoginModal({ open, onClose }: LoginModalProps) {
         >
           <X className="h-6 w-6" />
         </button>
-        {mode === "login" && (
-          <form onSubmit={handleLogin} className="flex flex-col gap-4 font-body">
-            <input
-              type="email"
-              placeholder="Email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="rounded-md border border-bodaghee-accent/50 bg-bodaghee-bg p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
-            />
-            <input
-              type="password"
-              placeholder="Пароль"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="rounded-md border border-bodaghee-accent/50 bg-bodaghee-bg p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
-            />
-            {error && <p className="text-bodaghee-accent">{error}</p>}
-            <div className="flex flex-wrap items-center gap-4">
+        {mode === "main" && (
+          <div className="flex flex-col gap-8 font-body md:flex-row">
+            <form
+              onSubmit={handleRegister}
+              className="flex w-full flex-col gap-4 md:w-1/2"
+            >
+              <h2 className="text-2xl font-bold text-white">Регистрация</h2>
+              <p className="text-sm text-white/70">
+                Создайте новый аккаунт
+              </p>
+              <input
+                type="text"
+                placeholder="Имя"
+                value={regName}
+                onChange={(e) => setRegName(e.target.value)}
+                className="rounded-md border border-white/20 bg-transparent p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
+              />
+              <input
+                type="email"
+                placeholder="Email"
+                value={regEmail}
+                onChange={(e) => setRegEmail(e.target.value)}
+                className="rounded-md border border-white/20 bg-transparent p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
+              />
+              <InputMask
+                mask="+7 (999) 999-99-99"
+                value={regPhone}
+                onChange={(e) => setRegPhone(e.target.value)}
+              >
+                {(inputProps: any) => (
+                  <input
+                    {...inputProps}
+                    type="tel"
+                    placeholder="Телефон"
+                    className="rounded-md border border-white/20 bg-transparent p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
+                  />
+                )}
+              </InputMask>
+              <input
+                type="password"
+                placeholder="Пароль"
+                value={regPassword}
+                onChange={(e) => setRegPassword(e.target.value)}
+                className="rounded-md border border-white/20 bg-transparent p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
+              />
+              {regError && <p className="text-bodaghee-accent">{regError}</p>}
               <button
                 type="submit"
-                className="rounded-md border border-bodaghee-accent bg-transparent px-4 py-2 text-white transition-colors hover:bg-bodaghee-accent hover:text-bodaghee-bg"
+                className="mt-2 rounded-md bg-bodaghee-accent px-4 py-2 font-semibold text-bodaghee-bg transition-colors hover:bg-bodaghee-accent/90"
               >
-                Войти
+                Зарегистрироваться
               </button>
-              <button
-                type="button"
-                onClick={() => setMode("forgot")}
-                className="text-sm text-bodaghee-accent underline"
-              >
-                Восстановить пароль
-              </button>
-              <button
-                type="button"
-                onClick={() => setMode("register")}
-                className="text-sm text-bodaghee-accent underline"
-              >
-                Регистрация
-              </button>
-            </div>
-          </form>
+            </form>
+            <form
+              onSubmit={handleLogin}
+              className="flex w-full flex-col gap-4 md:w-1/2 md:border-l md:border-bodaghee-accent/20 md:pl-8"
+            >
+              <h2 className="text-2xl font-bold text-white">Вход</h2>
+              <p className="text-sm text-white/70">Уже есть аккаунт? Войдите</p>
+              <input
+                type="email"
+                placeholder="Email"
+                value={loginEmail}
+                onChange={(e) => setLoginEmail(e.target.value)}
+                className="rounded-md border border-white/20 bg-transparent p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
+              />
+              <input
+                type="password"
+                placeholder="Пароль"
+                value={loginPassword}
+                onChange={(e) => setLoginPassword(e.target.value)}
+                className="rounded-md border border-white/20 bg-transparent p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
+              />
+              {loginError && <p className="text-bodaghee-accent">{loginError}</p>}
+              <div className="flex flex-wrap items-center gap-4">
+                <button
+                  type="submit"
+                  className="rounded-md bg-bodaghee-accent px-4 py-2 font-semibold text-bodaghee-bg transition-colors hover:bg-bodaghee-accent/90"
+                >
+                  Войти
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMode("forgot")}
+                  className="text-sm text-bodaghee-accent underline"
+                >
+                  Восстановить пароль
+                </button>
+              </div>
+            </form>
+          </div>
         )}
         {mode === "forgot" && (
           <form onSubmit={handleForgot} className="flex flex-col gap-4 font-body">
+            <h2 className="text-2xl font-bold text-white">Восстановление</h2>
+            <p className="text-sm text-white/70">
+              Укажите email для восстановления
+            </p>
             <input
               type="email"
               placeholder="Email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="rounded-md border border-bodaghee-accent/50 bg-bodaghee-bg p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
+              value={forgotEmail}
+              onChange={(e) => setForgotEmail(e.target.value)}
+              className="rounded-md border border-white/20 bg-transparent p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
             />
             {message && <p className="text-green-500">{message}</p>}
             <div className="flex items-center gap-4">
               <button
                 type="submit"
-                className="rounded-md border border-bodaghee-accent bg-transparent px-4 py-2 text-white transition-colors hover:bg-bodaghee-accent hover:text-bodaghee-bg"
+                className="rounded-md bg-bodaghee-accent px-4 py-2 font-semibold text-bodaghee-bg transition-colors hover:bg-bodaghee-accent/90"
               >
                 Отправить
               </button>
               <button
                 type="button"
-                onClick={() => setMode("login")}
-                className="text-sm text-bodaghee-accent underline"
-              >
-                Назад
-              </button>
-            </div>
-          </form>
-        )}
-        {mode === "register" && (
-          <form onSubmit={handleRegister} className="flex flex-col gap-4 font-body">
-            <input
-              type="text"
-              placeholder="Имя"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="rounded-md border border-bodaghee-accent/50 bg-bodaghee-bg p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
-            />
-            <input
-              type="email"
-              placeholder="Email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="rounded-md border border-bodaghee-accent/50 bg-bodaghee-bg p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
-            />
-            <InputMask
-              mask="+7 (999) 999-99-99"
-              value={phone}
-              onChange={(e) => setPhone(e.target.value)}
-            >
-              {(inputProps: any) => (
-                <input
-                  {...inputProps}
-                  type="tel"
-                  placeholder="Телефон"
-                  className="rounded-md border border-bodaghee-accent/50 bg-bodaghee-bg p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
-                />
-              )}
-            </InputMask>
-            <input
-              type="password"
-              placeholder="Пароль"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="rounded-md border border-bodaghee-accent/50 bg-bodaghee-bg p-3 text-white placeholder:text-white/50 focus:border-bodaghee-accent focus:outline-none"
-            />
-            {error && <p className="text-bodaghee-accent">{error}</p>}
-            <div className="flex items-center gap-4">
-              <button
-                type="submit"
-                className="rounded-md border border-bodaghee-accent bg-transparent px-4 py-2 text-white transition-colors hover:bg-bodaghee-accent hover:text-bodaghee-bg"
-              >
-                Зарегистрироваться
-              </button>
-              <button
-                type="button"
-                onClick={() => setMode("login")}
+                onClick={() => setMode("main")}
                 className="text-sm text-bodaghee-accent underline"
               >
                 Назад


### PR DESCRIPTION
## Summary
- redesign login/register modal with gradient styling and accent buttons
- handle login and registration side by side and add dedicated forgot password flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b4529dc17c8324813847b23524568b