### PR TITLE
fix: place terminationMessagePolicy under container

### DIFF
--- a/k8s/job-prisma-seed.yaml
+++ b/k8s/job-prisma-seed.yaml
@@ -10,10 +10,10 @@ spec:
   template:
     spec:
       restartPolicy: Never
-      terminationMessagePolicy: FallbackToLogsOnError
       containers:
         - name: seed
           image: ghcr.io/grayhex/afterlight-api:latest
+          terminationMessagePolicy: FallbackToLogsOnError
           imagePullPolicy: IfNotPresent
           env:
             - name: PRISMA_NON_INTERACTIVE


### PR DESCRIPTION
## Summary
- move terminationMessagePolicy into the seed container spec
- remove spec.template.spec-level terminationMessagePolicy

## Testing
- `kubectl create --dry-run=client -f k8s/job-prisma-seed.yaml` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b6f207e883248aa91e51dc109ad6