### PR TITLE
Persist password reset tokens and allow unauthenticated recovery endpoints

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -108,8 +108,23 @@ model User {
   vaultRoles    VaultUserRole[]
   decisions     VerificationDecision[]
   subscriptions Subscription[]
+  resetTokens   PasswordResetToken[]
 
   @@map("user")
+}
+
+model PasswordResetToken {
+  id        String   @id @default(uuid()) @map("id") @db.Uuid
+  userId    String   @map("user_id") @db.Uuid
+  tokenHash String   @map("token_hash")
+  expiresAt DateTime @map("expires_at")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([tokenHash], map: "ix_password_reset_token_hash")
+  @@index([expiresAt], map: "ix_password_reset_token_expires_at")
+  @@map("password_reset_token")
 }
 
 model Vault {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import * as jwt from 'jsonwebtoken';
-import { randomBytes } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
 import { hashPassword, verifyPassword } from './password';
 import { User, UserRole } from '@prisma/client';
@@ -9,15 +9,24 @@ import { NotificationsService } from '../notifications/notifications.service';
 @Injectable()
 export class AuthService {
   private readonly secret = process.env.JWT_SECRET || 'secret';
-  private readonly resetTokens = new Map<
-    string,
-    { userId: string; expires: number }
-  >();
 
   constructor(
     private readonly prisma: PrismaService,
     private readonly notifications: NotificationsService,
   ) {}
+
+  private hashToken(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
+  }
+
+  private get resetTokenRepo() {
+    return (this.prisma as any).passwordResetToken as {
+      deleteMany(args: any): Promise<any>;
+      create(args: any): Promise<any>;
+      findFirst(args: any): Promise<any>;
+      delete(args: any): Promise<any>;
+    };
+  }
 
   sign(userId: string): string {
     return jwt.sign({ sub: userId }, this.secret, { expiresIn: '1h' });
@@ -50,10 +59,18 @@ export class AuthService {
   async forgotPassword(email: string) {
     const user = await this.prisma.user.findUnique({ where: { email } });
     if (!user) return;
-    const token = randomBytes(16).toString('hex');
-    this.resetTokens.set(token, {
-      userId: user.id,
-      expires: Date.now() + 60 * 60 * 1000,
+    const token = randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    const tokenHash = this.hashToken(token);
+    await this.resetTokenRepo.deleteMany({
+      where: { userId: user.id },
+    });
+    await this.resetTokenRepo.create({
+      data: {
+        userId: user.id,
+        tokenHash,
+        expiresAt,
+      },
     });
     const vault = await this.prisma.vault.findFirst({
       where: { userId: user.id },
@@ -69,14 +86,24 @@ export class AuthService {
   }
 
   async resetPassword(token: string, password: string): Promise<boolean> {
-    const entry = this.resetTokens.get(token);
-    if (!entry || entry.expires < Date.now()) return false;
-    const passwordHash = await hashPassword(password);
-    await this.prisma.user.update({
-      where: { id: entry.userId },
-      data: { passwordHash },
+    const tokenHash = this.hashToken(token);
+    const entry = await this.resetTokenRepo.findFirst({
+      where: {
+        tokenHash,
+        expiresAt: {
+          gt: new Date(),
+        },
+      },
     });
-    this.resetTokens.delete(token);
+    if (!entry) return false;
+    const passwordHash = await hashPassword(password);
+    await (this.prisma as any).$transaction(async (tx: any) => {
+      await tx.user.update({
+        where: { id: entry.userId },
+        data: { passwordHash },
+      });
+      await tx.passwordResetToken.delete({ where: { id: entry.id } });
+    });
     return true;
   }
 

--- a/apps/api/src/auth/guards/auth.guard.ts
+++ b/apps/api/src/auth/guards/auth.guard.ts
@@ -7,8 +7,18 @@ export class AuthGuard implements CanActivate {
 
   canActivate(context: ExecutionContext): boolean {
     const req = context.switchToHttp().getRequest();
-    const openPaths = ['/auth/login', '/auth/register', '/auth/logout', '/healthz', '/readyz'];
-    if (openPaths.includes(req.path)) {
+    const openPaths = new Set([
+      '/auth/login',
+      '/auth/register',
+      '/auth/logout',
+      '/auth/forgot-password',
+      '/auth/reset-password',
+      '/healthz',
+      '/readyz',
+      '/docs-json',
+    ]);
+    const openPrefixes = ['/docs'];
+    if (openPaths.has(req.path) || openPrefixes.some((p) => req.path.startsWith(p))) {
       return true;
     }
     const authHeader = req.headers['authorization'] || '';

--- a/apps/api/test/auth.service.spec.ts
+++ b/apps/api/test/auth.service.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { AuthService } from '../src/auth/auth.service';
+import { createHash } from 'crypto';
+
+describe('AuthService password reset flow', () => {
+  let prisma: any;
+  let notifications: any;
+  let service: AuthService;
+
+  beforeEach(() => {
+    prisma = {
+      user: {
+        findUnique: jest.fn(async () => ({ id: 'user-1', email: 'user@example.com' })),
+        update: jest.fn(async (args: { data: any }) => ({ id: 'user-1', ...args.data })),
+      },
+      vault: {
+        findFirst: jest.fn(async () => ({ id: 'vault-1' })),
+      },
+      passwordResetToken: {
+        deleteMany: jest.fn(async () => ({ count: 1 })),
+        create: jest.fn(async ({ data }) => ({ id: 'token-1', ...data })),
+        findFirst: jest.fn(),
+        delete: jest.fn(async () => ({})),
+      },
+      $transaction: jest.fn(async (callback: (tx: any) => Promise<any>) => {
+        await callback({
+          user: { update: prisma.user.update },
+          passwordResetToken: {
+            delete: prisma.passwordResetToken.delete,
+          },
+        });
+      }),
+    };
+
+    notifications = {
+      enqueueEmail: jest.fn(async () => ({})),
+      flushEmailQueue: jest.fn(async () => ({})),
+    };
+
+    service = new AuthService(prisma, notifications);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('persists hashed reset token and queues email with raw token', async () => {
+    const emailPayloads: any[] = [];
+    notifications.enqueueEmail.mockImplementation(
+      async (_vaultId: string, _to: string, payload: any) => {
+        emailPayloads.push(payload);
+        return {};
+      },
+    );
+
+    let createdTokenData: any = null;
+    prisma.passwordResetToken.create.mockImplementation(async ({ data }: { data: any }) => {
+      createdTokenData = data;
+      return { id: 'token-1', ...data };
+    });
+
+    await service.forgotPassword('user@example.com');
+
+    expect(prisma.passwordResetToken.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+    });
+    expect(createdTokenData).not.toBeNull();
+    expect(createdTokenData.userId).toBe('user-1');
+    expect(createdTokenData.tokenHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(createdTokenData.expiresAt).toBeInstanceOf(Date);
+
+    expect(notifications.enqueueEmail).toHaveBeenCalledTimes(1);
+    const payload = emailPayloads[0];
+    expect(payload.subject).toContain('восстановление пароля');
+    const tokenMatch = payload.text?.match(/[0-9a-f]{64}/i);
+    expect(tokenMatch).not.toBeNull();
+    const tokenFromEmail = tokenMatch![0];
+    const hashed = createHash('sha256').update(tokenFromEmail).digest('hex');
+    expect(hashed).toBe(createdTokenData.tokenHash);
+    expect(notifications.flushEmailQueue).toHaveBeenCalled();
+  });
+
+  it('resets password and removes token when hash matches an active record', async () => {
+    const rawToken = 'abcd'.repeat(16);
+    const tokenHash = createHash('sha256').update(rawToken).digest('hex');
+    prisma.passwordResetToken.findFirst.mockResolvedValue({
+      id: 'token-1',
+      userId: 'user-1',
+      tokenHash,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    const result = await service.resetPassword(rawToken, 'newPassword123');
+
+    expect(result).toBe(true);
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: expect.objectContaining({ passwordHash: expect.stringContaining(':') }),
+    });
+    expect(prisma.passwordResetToken.delete).toHaveBeenCalledWith({ where: { id: 'token-1' } });
+  });
+
+  it('returns false when token is missing or expired', async () => {
+    prisma.passwordResetToken.findFirst.mockResolvedValue(null);
+
+    const result = await service.resetPassword('invalid', 'password');
+
+    expect(result).toBe(false);
+    expect(prisma.user.update).not.toHaveBeenCalled();
+    expect(prisma.passwordResetToken.delete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated password_reset_token model and persist forgot-password tokens in Prisma
- relax the auth guard to expose recovery and documentation routes without a JWT
- cover the new password reset flow with focused AuthService unit tests

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68ebe884a50883249782868b5e298efb