### PR TITLE
Align vault creation UI with API fields

### DIFF
--- a/apps/api/prisma/migrations/20260208080000_add_vault_name_description/migration.sql
+++ b/apps/api/prisma/migrations/20260208080000_add_vault_name_description/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "vault" ADD COLUMN "name" TEXT NOT NULL DEFAULT 'Без названия';
+ALTER TABLE "vault" ADD COLUMN "description" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -130,6 +130,8 @@ model PasswordResetToken {
 model Vault {
   id                   String      @id @default(uuid()) @map("id") @db.Uuid
   userId               String      @map("user_id") @db.Uuid
+  name                 String      @default("Без названия")
+  description          String?
   status               VaultStatus @default(Active)
   quorumThreshold      Int         @default(3) @map("quorum_threshold")
   maxVerifiers         Int         @default(5) @map("max_verifiers")

--- a/apps/api/src/vaults/dto/create-vault.dto.ts
+++ b/apps/api/src/vaults/dto/create-vault.dto.ts
@@ -1,16 +1,28 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { IsBoolean, IsInt, IsOptional, IsString, Max, Min, MaxLength } from 'class-validator';
 
 export class CreateVaultDto {
+  @ApiProperty({ required: false, description: 'Vault display name', maxLength: 120 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  name?: string;
+
+  @ApiProperty({ required: false, description: 'Optional vault description', maxLength: 500 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
   @ApiProperty({ required: false, default: false })
   @IsOptional()
   @IsBoolean()
   is_demo?: boolean;
 
-  @ApiProperty({ required: false, minimum: 3, maximum: 5, default: 3 })
+  @ApiProperty({ required: false, minimum: 2, maximum: 5, default: 2 })
   @IsOptional()
   @IsInt()
-  @Min(3)
+  @Min(2)
   @Max(5)
   quorum_threshold?: number;
 

--- a/apps/api/src/vaults/dto/update-vault-settings.dto.ts
+++ b/apps/api/src/vaults/dto/update-vault-settings.dto.ts
@@ -2,10 +2,10 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsOptional, IsUUID, Max, Min } from 'class-validator';
 
 export class UpdateVaultSettingsDto {
-  @ApiProperty({ required: false, minimum: 3, maximum: 5 })
+  @ApiProperty({ required: false, minimum: 2, maximum: 5 })
   @IsOptional()
   @IsInt()
-  @Min(3)
+  @Min(2)
   @Max(5)
   quorum_threshold?: number;
 

--- a/apps/api/src/vaults/vaults.service.ts
+++ b/apps/api/src/vaults/vaults.service.ts
@@ -28,16 +28,20 @@ export class VaultsService {
 
   async createForUser(userId: string, dto: CreateVaultDto) {
     const defaults = {
-      quorumThreshold: 3,
+      quorumThreshold: 2,
       maxVerifiers: 5,
       heartbeatTimeoutDays: 60,
       graceHours: 24,
       isDemo: false,
     };
+    const name = dto.name?.trim();
+    const description = dto.description?.trim();
     const mkWrapped = randomBytes(32).toString('base64');
     const vault = await this.prisma.vault.create({
       data: {
         userId,
+        ...(name ? { name } : {}),
+        ...(description ? { description } : {}),
         status: 'Active',
         quorumThreshold: dto.quorum_threshold ?? defaults.quorumThreshold,
         maxVerifiers: dto.max_verifiers ?? defaults.maxVerifiers,

--- a/apps/web/src/app/cabinet/page.tsx
+++ b/apps/web/src/app/cabinet/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { httpClient } from "@/shared/api/httpClient";
 import { useAuth } from "@/shared/auth/useAuth";
 import { AnimatePresence, motion } from "framer-motion";
@@ -32,6 +32,7 @@ function OwnerCabinet() {
   const [vaults, setVaults] = useState<any[]>([]);
   const [vaultsLoading, setVaultsLoading] = useState(false);
   const [vaultsError, setVaultsError] = useState<string | null>(null);
+  const [selectedVaultId, setSelectedVaultId] = useState<string | null>(null);
 
   const [showModal, setShowModal] = useState(false);
   const [name, setName] = useState("");
@@ -48,64 +49,128 @@ function OwnerCabinet() {
   const [inviting, setInviting] = useState(false);
   const [inviteError, setInviteError] = useState<string | null>(null);
 
-  useEffect(() => {
-    async function loadVaults() {
-      setVaultsLoading(true);
-      setVaultsError(null);
-      try {
-        const res = await httpClient("/vaults", { method: "GET" });
-        const data = await res.json();
-        setVaults(data);
-      } catch (e) {
-        setVaultsError("Ошибка загрузки");
-      } finally {
-        setVaultsLoading(false);
+  const loadVaults = useCallback(async () => {
+    setVaultsLoading(true);
+    setVaultsError(null);
+    try {
+      const res = await httpClient("/vaults", { method: "GET" });
+      if (!res.ok) {
+        throw new Error("Ошибка загрузки");
       }
+      const data = await res.json();
+      setVaults(data);
+      if (data.length > 0) {
+        setSelectedVaultId((current) => current ?? data[0].id);
+      }
+    } catch (e) {
+      setVaultsError("Ошибка загрузки");
+    } finally {
+      setVaultsLoading(false);
     }
-    loadVaults();
+  }, []);
+
+  const loadVerifiers = useCallback(async (vaultId: string) => {
+    setVerifiersLoading(true);
+    setVerifiersError(null);
+    try {
+      const res = await httpClient(
+        `/verifiers?vault_id=${encodeURIComponent(vaultId)}`,
+        { method: "GET" },
+      );
+      if (!res.ok) {
+        throw new Error("Ошибка загрузки");
+      }
+      const data = await res.json();
+      setVerifiers(data);
+    } catch (e) {
+      setVerifiersError("Ошибка загрузки");
+    } finally {
+      setVerifiersLoading(false);
+    }
   }, []);
 
   useEffect(() => {
-    async function loadVerifiers() {
-      setVerifiersLoading(true);
-      setVerifiersError(null);
-      try {
-        const res = await httpClient("/verifiers", { method: "GET" });
-        const data = await res.json();
-        setVerifiers(data);
-      } catch (e) {
-        setVerifiersError("Ошибка загрузки");
-      } finally {
-        setVerifiersLoading(false);
-      }
+    loadVaults();
+  }, [loadVaults]);
+
+  useEffect(() => {
+    if (!selectedVaultId) {
+      setVerifiers([]);
+      return;
     }
-    loadVerifiers();
-  }, []);
+    loadVerifiers(selectedVaultId);
+  }, [loadVerifiers, selectedVaultId]);
 
   const handleCreate = async () => {
     setCreating(true);
     setCreateError(null);
+    const trimmedName = name.trim();
+    const trimmedDescription = description.trim();
+    const verifierList = verifierEmails
+      .map((email) => email.trim())
+      .filter(Boolean);
+
+    if (!trimmedName) {
+      setCreateError("Укажите название сейфа");
+      setCreating(false);
+      return;
+    }
+    if (verifierList.length === 0) {
+      setCreateError("Добавьте хотя бы одного верификатора");
+      setCreating(false);
+      return;
+    }
+    if (quorum > verifierList.length) {
+      setCreateError("Кворум не может быть больше числа верификаторов");
+      setCreating(false);
+      return;
+    }
+
     try {
       const body = {
-        name,
-        description,
-        verifiers: verifierEmails,
-        quorum,
+        name: trimmedName,
+        description: trimmedDescription || undefined,
+        quorum_threshold: quorum,
       };
       const res = await httpClient("/vaults", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
+      if (!res.ok) {
+        const error = await res.json().catch(() => null);
+        throw new Error(error?.message || "Ошибка создания");
+      }
       const data = await res.json();
       setVaults((v) => [...v, data]);
+      setSelectedVaultId(data.id);
+      const inviteResults = await Promise.allSettled(
+        verifierList.map(async (email) => {
+          const inviteRes = await httpClient("/verifiers/invitations", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email, vault_id: data.id }),
+          });
+          if (!inviteRes.ok) {
+            const error = await inviteRes.json().catch(() => null);
+            throw new Error(error?.message || "Ошибка приглашения");
+          }
+          return inviteRes.json();
+        }),
+      );
+      const failed = inviteResults.filter((result) => result.status === "rejected");
+      if (failed.length > 0) {
+        setCreateError("Часть приглашений не отправилась");
+      }
+      await loadVerifiers(data.id);
       setShowModal(false);
       setName("");
       setDescription("");
       setVerifierEmails(["", "", ""]);
       setQuorum(2);
     } catch (e) {
-      setCreateError("Ошибка создания");
+      const message = e instanceof Error ? e.message : "Ошибка создания";
+      setCreateError(message);
     } finally {
       setCreating(false);
     }
@@ -114,19 +179,33 @@ function OwnerCabinet() {
   const handleInvite = async () => {
     setInviting(true);
     setInviteError(null);
+    const email = inviteEmail.trim();
+    if (!selectedVaultId) {
+      setInviteError("Сначала выберите сейф");
+      setInviting(false);
+      return;
+    }
+    if (!email) {
+      setInviteError("Введите e-mail");
+      setInviting(false);
+      return;
+    }
     try {
-        const res = await httpClient("/verifiers/invitations", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: inviteEmail }),
-        });
-        const data = await res.json();
-        const email =
-          data?.invitation?.user?.email || data?.email || inviteEmail;
-        setVerifiers((v) => [...v, { email }]);
+      const res = await httpClient("/verifiers/invitations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, vault_id: selectedVaultId }),
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => null);
+        throw new Error(error?.message || "Ошибка приглашения");
+      }
+      await res.json();
+      await loadVerifiers(selectedVaultId);
       setInviteEmail("");
     } catch (e) {
-      setInviteError("Ошибка приглашения");
+      const message = e instanceof Error ? e.message : "Ошибка приглашения";
+      setInviteError(message);
     } finally {
       setInviting(false);
     }
@@ -150,17 +229,19 @@ function OwnerCabinet() {
         {!vaultsLoading && !vaultsError && (
           <div className="mt-4 grid gap-4 md:grid-cols-2">
             <AnimatePresence>
-              {vaults.map((v: any, idx: number) => (
+              {vaults.map((v: any) => (
                 <motion.div
-                  key={idx}
+                  key={v.id}
                   layout
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                   className="rounded bg-bodaghee-bg p-4 text-white shadow"
                 >
-                  <div className="font-bold">{v.name}</div>
-                  <div className="text-sm text-white/70">{v.description}</div>
+                  <div className="font-bold">{v.name || "Без названия"}</div>
+                  {v.description ? (
+                    <div className="text-sm text-white/70">{v.description}</div>
+                  ) : null}
                 </motion.div>
               ))}
             </AnimatePresence>
@@ -169,17 +250,33 @@ function OwnerCabinet() {
       </div>
 
       <div>
-        <h2 className="mb-2 text-xl">Верификаторы</h2>
+        <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="text-xl">Верификаторы</h2>
+          <select
+            className="rounded border border-bodaghee-accent bg-bodaghee-bg px-3 py-2 text-white"
+            value={selectedVaultId ?? ""}
+            onChange={(e) => setSelectedVaultId(e.target.value || null)}
+          >
+            <option value="" disabled>
+              Выберите сейф
+            </option>
+            {vaults.map((vault) => (
+              <option key={vault.id} value={vault.id}>
+                {vault.name || vault.id}
+              </option>
+            ))}
+          </select>
+        </div>
         {verifiersError && (
           <p className="mt-2 text-bodaghee-accent">{verifiersError}</p>
         )}
         {verifiersLoading && <p className="mt-2">Загрузка...</p>}
-        {!verifiersLoading && !verifiersError && (
+        {!verifiersLoading && !verifiersError && selectedVaultId && (
           <div className="grid gap-4 md:grid-cols-2">
             <AnimatePresence>
                 {verifiers.map((v: any, idx: number) => (
                   <motion.div
-                    key={idx}
+                    key={v.userId || v.user?.id || idx}
                   layout
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
@@ -191,6 +288,9 @@ function OwnerCabinet() {
                 ))}
             </AnimatePresence>
           </div>
+        )}
+        {!verifiersLoading && !verifiersError && !selectedVaultId && (
+          <p className="text-sm text-white/70">Выберите сейф, чтобы увидеть список.</p>
         )}
 
         <div className="mt-4 flex flex-col gap-2 sm:flex-row">
@@ -238,7 +338,7 @@ function OwnerCabinet() {
                 />
                 <textarea
                   className="col-span-full rounded border border-bodaghee-accent bg-bodaghee-bg p-2 text-white placeholder:text-white/50 transition-colors focus:border-bodaghee-accent"
-                  placeholder="Описани (необязательно)"
+                  placeholder="Описание (необязательно)"
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                 />
@@ -257,11 +357,11 @@ function OwnerCabinet() {
                   />
                 ))}
                 <p className="col-span-full text-sm text-white/70">
-                  Добавьте три человека, которым вы доверяете. Доступ откроется при подтверждении двух из них.
+                  Добавьте доверенных людей и укажите, сколько подтверждений требуется для доступа.
                 </p>
                 <input
                   type="number"
-                  min={1}
+                  min={2}
                   max={3}
                   className="col-span-full rounded border border-bodaghee-accent bg-bodaghee-bg p-2 text-white transition-colors focus:border-bodaghee-accent"
                   value={quorum}
@@ -387,4 +487,3 @@ function VerifierCabinet() {
     </div>
   );
 }
-


### PR DESCRIPTION
### Motivation
- Add human-friendly vault metadata and align backend creation behavior with the updated frontend flow so vaults created from the UI store a name/description and respect new quorum defaults.
- Make the Owner cabinet UX able to select a vault, validate inputs before create, and send verifier invitations automatically to match API expectations.

### Description
- Add `name` and `description` columns to the `Vault` model and include a SQL migration file to add the columns to the database.
- Extend `CreateVaultDto` with optional `name` and `description`, relax quorum minimum to `2`, and mirror the same minimum in `UpdateVaultSettingsDto`.
- Update `VaultsService.createForUser` to accept and persist trimmed `name`/`description`, change the default quorum to `2`, and keep existing audit logging.
- Revamp the Owner cabinet page (`apps/web/src/app/cabinet/page.tsx`) to load/select vaults, validate name/quorum/verifiers when creating a vault, post the proper `vault_id` when sending verifier invitations, and surface errors from API responses.

### Testing
- Ran `npm -C apps/api test` and all test suites passed (7 suites, 17 tests, all green).
- Built the frontend with `npm -C apps/web run build` and the Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69883d23ef208324bbdc41923c447648)