### PR TITLE
Зафиксировать роль при публичной регистрации

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -30,7 +30,6 @@ export class AuthController {
       dto.email,
       dto.phone,
       dto.password,
-      dto.role,
     );
     const { id, email, role } = user;
     return { id, email, role };

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -37,9 +37,8 @@ export class AuthService {
     email: string,
     phone: string,
     password?: string,
-    role: UserRole = UserRole.Owner,
   ): Promise<User> {
-    const data: any = { name, email, phone, role };
+    const data: any = { name, email, phone, role: UserRole.Owner };
     if (password) {
       data.passwordHash = await hashPassword(password);
     }

--- a/apps/api/src/auth/dto/register.dto.ts
+++ b/apps/api/src/auth/dto/register.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, IsOptional, IsEnum } from 'class-validator';
-import { UserRole } from '@prisma/client';
+import { IsEmail, IsString, IsOptional } from 'class-validator';
 
 export class RegisterDto {
   @ApiProperty()
@@ -20,8 +19,4 @@ export class RegisterDto {
   @IsString()
   password?: string;
 
-  @ApiProperty({ required: false, enum: UserRole })
-  @IsOptional()
-  @IsEnum(UserRole)
-  role?: UserRole;
 }


### PR DESCRIPTION
### Motivation
- Предотвратить возможность клиенту задавать роль при публичной регистрации и обеспечить, что публичные аккаунты всегда создаются с безопасной ролью.
- Вынести создание привилегированных пользователей (Admin/Verifier) в отдельную защищённую админскую логику.

### Description
- Удалено поле `role` из публичного DTO регистрации `RegisterDto` и удалены связанные импорты `IsEnum` и `UserRole` в `apps/api/src/auth/dto/register.dto.ts`.
- В `apps/api/src/auth/auth.controller.ts` метод `register` больше не передаёт `dto.role` в `AuthService.register` и отправляет только `name/email/phone/password`.
- В `apps/api/src/auth/auth.service.ts` параметр `role` удалён из сигнатуры метода `register`, и при создании пользователя роль жёстко установлена в `UserRole.Owner`.
- Изменения касаются файлов: `apps/api/src/auth/dto/register.dto.ts`, `apps/api/src/auth/auth.controller.ts`, `apps/api/src/auth/auth.service.ts`.

### Testing
- Выполнена сборка проекта сервиса API командой `npm run build` в `apps/api`, сборка завершилась успешно.
- Локальных автоматизированных тестов (`jest`) не запускалось в этом прогона сборки.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e55d48e88324a60d6b0cb495f885)