### PR TITLE
Add RolesGuard and vault-scoped access checks for verifiers/recipients

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { AuthGuard } from './guards/auth.guard';
+import { RolesGuard } from './guards/roles.guard';
 import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [NotificationsModule],
   controllers: [AuthController],
-  providers: [AuthService, AuthGuard],
-  exports: [AuthService, AuthGuard],
+  providers: [AuthService, AuthGuard, RolesGuard],
+  exports: [AuthService, AuthGuard, RolesGuard],
 })
 export class AuthModule {}

--- a/apps/api/src/auth/decorators/roles.decorator.ts
+++ b/apps/api/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from '@prisma/client';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/apps/api/src/auth/guards/roles.guard.ts
+++ b/apps/api/src/auth/guards/roles.guard.ts
@@ -1,0 +1,39 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UserRole } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const req = context.switchToHttp().getRequest();
+    const userId = req.user?.sub;
+    if (!userId) {
+      throw new ForbiddenException('Access denied');
+    }
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { role: true },
+    });
+    if (!user || !requiredRoles.includes(user.role)) {
+      throw new ForbiddenException('Insufficient role');
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,6 +4,7 @@ import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { PrismaService } from './prisma/prisma.service';
 import { AuthGuard } from './auth/guards/auth.guard';
+import { RolesGuard } from './auth/guards/roles.guard';
 import helmet from 'helmet';
 import { json } from 'express';
 
@@ -27,6 +28,7 @@ async function bootstrap() {
   }));
 
   app.useGlobalGuards(app.get(AuthGuard));
+  app.useGlobalGuards(app.get(RolesGuard));
 
   const config = new DocumentBuilder()
     .setTitle('AfterLight API')

--- a/apps/api/src/recipients/dto/create-recipient.dto.ts
+++ b/apps/api/src/recipients/dto/create-recipient.dto.ts
@@ -1,7 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsEmail, IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
 
 export class CreateRecipientDto {
+  @ApiProperty({ description: 'Идентификатор сейфа' })
+  @IsUUID()
+  vault_id!: string;
+
   @ApiProperty({ description: 'Email получателя (уникальный идентификатор)' })
   @IsEmail()
   contact!: string;

--- a/apps/api/src/recipients/dto/search-recipients.dto.ts
+++ b/apps/api/src/recipients/dto/search-recipients.dto.ts
@@ -1,7 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
 
 export class SearchRecipientsDto {
+  @ApiProperty({ description: 'Идентификатор сейфа' })
+  @IsUUID()
+  vault_id!: string;
+
   @ApiProperty({ required: false, description: 'Подстрока для поиска по contact' })
   @IsOptional()
   @IsString()

--- a/apps/api/src/recipients/recipients.controller.ts
+++ b/apps/api/src/recipients/recipients.controller.ts
@@ -4,6 +4,7 @@ import { RecipientsService } from './recipients.service';
 import { CreateRecipientDto } from './dto/create-recipient.dto';
 import { SearchRecipientsDto } from './dto/search-recipients.dto';
 import { ApiErrorResponses } from '../common/api-error-responses.decorator';
+import { CurrentUser, AuthenticatedUser } from '../common/current-user.decorator';
 
 @ApiTags('recipients')
 @ApiBearerAuth()
@@ -13,12 +14,12 @@ export class RecipientsController {
   constructor(private readonly service: RecipientsService) {}
 
   @Post()
-  create(@Body() dto: CreateRecipientDto) {
-    return this.service.createOrGet(dto);
+  create(@CurrentUser() user: AuthenticatedUser, @Body() dto: CreateRecipientDto) {
+    return this.service.createOrGet(user, dto);
   }
 
   @Get()
-  search(@Query() q: SearchRecipientsDto) {
-    return this.service.search(q.q);
+  search(@CurrentUser() user: AuthenticatedUser, @Query() q: SearchRecipientsDto) {
+    return this.service.search(user, q.vault_id, q.q);
   }
 }

--- a/apps/api/src/recipients/recipients.service.ts
+++ b/apps/api/src/recipients/recipients.service.ts
@@ -1,12 +1,33 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { UserRole } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateRecipientDto } from './dto/create-recipient.dto';
+import { AuthenticatedUser } from '../common/current-user.decorator';
 
 @Injectable()
 export class RecipientsService {
   constructor(private prisma: PrismaService) {}
 
-  async createOrGet(dto: CreateRecipientDto) {
+  private async ensureVaultAccess(userId: string, vaultId: string) {
+    const ownedVault = await this.prisma.vault.findFirst({ where: { id: vaultId, userId } });
+    if (ownedVault) return;
+
+    const link = await this.prisma.vaultUserRole.findFirst({
+      where: {
+        vaultId,
+        userId,
+        status: 'Active',
+        role: { in: [UserRole.Admin, UserRole.Owner, UserRole.Verifier] },
+      },
+    });
+    if (!link) {
+      throw new ForbiddenException('Vault not found or access denied');
+    }
+  }
+
+  async createOrGet(user: AuthenticatedUser, dto: CreateRecipientDto) {
+    await this.ensureVaultAccess(user.sub, dto.vault_id);
+
     const r = await this.prisma.recipient.upsert({
       where: { contact: dto.contact },
       update: { pubkey: dto.pubkey ?? undefined },
@@ -15,10 +36,25 @@ export class RecipientsService {
     return r;
   }
 
-  async search(query?: string) {
+  async search(user: AuthenticatedUser, vaultId: string, query?: string) {
+    await this.ensureVaultAccess(user.sub, vaultId);
+
     const where = query
       ? { contact: { contains: query, mode: 'insensitive' as const } }
       : {};
-    return this.prisma.recipient.findMany({ where, take: 20, orderBy: { createdAt: 'desc' } });
+    return this.prisma.recipient.findMany({
+      where: {
+        ...where,
+        blocks: {
+          some: {
+            block: {
+              vaultId,
+            },
+          },
+        },
+      },
+      take: 20,
+      orderBy: { createdAt: 'desc' },
+    });
   }
 }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,14 +1,17 @@
 import { Controller, Get, Post, Patch, Delete, Param, Body } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOkResponse, ApiCreatedResponse } from '@nestjs/swagger';
+import { UserRole } from '@prisma/client';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserDto } from './dto/user.dto';
 import { ApiErrorResponses } from '../common/api-error-responses.decorator';
+import { Roles } from '../auth/decorators/roles.decorator';
 
 @ApiTags('users')
 @ApiBearerAuth()
 @ApiErrorResponses()
+@Roles(UserRole.Admin)
 @Controller('users')
 export class UsersController {
   constructor(private readonly service: UsersService) {}

--- a/apps/api/src/verifiers/verifiers.controller.ts
+++ b/apps/api/src/verifiers/verifiers.controller.ts
@@ -4,6 +4,7 @@ import { randomBytes } from 'crypto';
 import { VerifiersService } from './verifiers.service';
 import { InviteVerifierDto } from './dto/invite-verifier.dto';
 import { ApiErrorResponses } from '../common/api-error-responses.decorator';
+import { CurrentUser, AuthenticatedUser } from '../common/current-user.decorator';
 
 @ApiTags('verifiers')
 @ApiBearerAuth()
@@ -13,18 +14,22 @@ export class VerifiersController {
   constructor(private readonly service: VerifiersService) {}
 
   @Get()
-  list(@Query('vault_id') vaultId: string) {
-    return this.service.listByVault(vaultId);
+  list(@CurrentUser() user: AuthenticatedUser, @Query('vault_id') vaultId: string) {
+    return this.service.listByVault(user, vaultId);
   }
 
   @Post('invitations')
-  invite(@Body() dto: InviteVerifierDto) {
+  invite(@CurrentUser() user: AuthenticatedUser, @Body() dto: InviteVerifierDto) {
     const token = randomBytes(24).toString('hex');
-    return this.service.invite(dto, token);
+    return this.service.invite(user, dto, token);
   }
 
   @Post('invitations/:vaultId/:userId/accept')
-  accept(@Param('vaultId') vaultId: string, @Param('userId') userId: string) {
-    return this.service.acceptInvitation(vaultId, userId);
+  accept(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('vaultId') vaultId: string,
+    @Param('userId') userId: string,
+  ) {
+    return this.service.acceptInvitation(user, vaultId, userId);
   }
 }

--- a/apps/api/src/verifiers/verifiers.service.ts
+++ b/apps/api/src/verifiers/verifiers.service.ts
@@ -2,16 +2,42 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
+import { UserRole, VaultUserRoleStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { InviteVerifierDto } from './dto/invite-verifier.dto';
 import { NotificationsService } from '../notifications/notifications.service';
+import { AuthenticatedUser } from '../common/current-user.decorator';
 
 @Injectable()
 export class VerifiersService {
   constructor(private prisma: PrismaService, private notify: NotificationsService) {}
 
-  async listByVault(vaultId: string) {
+  private async ensureVaultAccess(
+    userId: string,
+    vaultId: string,
+    statuses: VaultUserRoleStatus[] = ['Active'],
+  ) {
+    const ownedVault = await this.prisma.vault.findFirst({ where: { id: vaultId, userId } });
+    if (ownedVault) return;
+
+    const link = await this.prisma.vaultUserRole.findFirst({
+      where: {
+        vaultId,
+        userId,
+        status: { in: statuses },
+        role: { in: [UserRole.Admin, UserRole.Owner, UserRole.Verifier] },
+      },
+    });
+
+    if (!link) {
+      throw new ForbiddenException('Vault not found or access denied');
+    }
+  }
+
+  async listByVault(user: AuthenticatedUser, vaultId: string) {
+    await this.ensureVaultAccess(user.sub, vaultId);
     return this.prisma.vaultUserRole.findMany({
       where: { vaultId },
       include: { user: true },
@@ -19,22 +45,24 @@ export class VerifiersService {
     });
   }
 
-  async invite(dto: InviteVerifierDto, token: string) {
-    const user = await this.prisma.user.upsert({
+  async invite(user: AuthenticatedUser, dto: InviteVerifierDto, token: string) {
+    await this.ensureVaultAccess(user.sub, dto.vault_id);
+
+    const invitedUser = await this.prisma.user.upsert({
       where: { email: dto.email },
       update: {},
       create: { email: dto.email, role: 'Verifier' },
     });
 
     const existing = await this.prisma.vaultUserRole.findUnique({
-      where: { vaultId_userId: { vaultId: dto.vault_id, userId: user.id } },
+      where: { vaultId_userId: { vaultId: dto.vault_id, userId: invitedUser.id } },
     });
     if (existing) throw new BadRequestException('Already invited');
 
     const link = await this.prisma.vaultUserRole.create({
       data: {
         vaultId: dto.vault_id,
-        userId: user.id,
+        userId: invitedUser.id,
         role: 'Verifier',
         status: 'Invited',
         isPrimary: false,
@@ -60,7 +88,9 @@ export class VerifiersService {
     return { invitation: link, token };
   }
 
-  async acceptInvitation(vaultId: string, userId: string) {
+  async acceptInvitation(user: AuthenticatedUser, vaultId: string, userId: string) {
+    await this.ensureVaultAccess(user.sub, vaultId, ['Active', 'Invited']);
+
     const link = await this.prisma.vaultUserRole.findUnique({
       where: { vaultId_userId: { vaultId, userId } },
     });


### PR DESCRIPTION
### Motivation
- Introduce role-based authorization to protect administrative endpoints (Admin only) and centralize role checks. 
- Prevent anonymous/global access to verifiers/recipients operations by enforcing vault-scoped access control. 
- Ensure controller methods pass the authenticated user into services so services can enforce owner/role checks. 

### Description
- Added a reusable `@Roles(...)` decorator at `apps/api/src/auth/decorators/roles.decorator.ts` and implemented `RolesGuard` in `apps/api/src/auth/guards/roles.guard.ts`. 
- Registered `RolesGuard` in `AuthModule` and enabled it globally in `main.ts`. 
- Applied `@Roles(UserRole.Admin)` to the `UsersController` so user-management endpoints are Admin-only. 
- Verifiers: updated `verifiers.controller.ts` to pass `@CurrentUser()` into service calls and updated `verifiers.service.ts` to add `ensureVaultAccess(...)` and enforce access checks before `listByVault`, `invite`, and `acceptInvitation`. 
- Recipients: added `vault_id` to DTOs (`create-recipient.dto.ts`, `search-recipients.dto.ts`), updated `recipients.controller.ts` to pass `@CurrentUser()` to services, and changed `recipients.service.ts` to check vault access and limit `search` to recipients linked to the requested vault via `blocks` association. 

### Testing
- Ran `npm run build` in `apps/api` and the project compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e6fce24c8324a44790b1119bdf2e)