### PR TITLE
Harden auth cookies and remove Basic auth cookie

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -15,13 +15,20 @@ import { RegisterDto } from './dto/register.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
 import { Response, Request } from 'express';
-import { UserRole } from '@prisma/client';
 
 @ApiTags('auth')
 @ApiErrorResponses()
 @Controller('auth')
 export class AuthController {
   constructor(private readonly auth: AuthService) {}
+
+  private readonly tokenCookieOptions = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax' as const,
+    maxAge: 60 * 60 * 1000,
+    path: '/',
+  };
 
   @Post('register')
   async register(@Body() dto: RegisterDto) {
@@ -45,21 +52,19 @@ export class AuthController {
       throw new UnauthorizedException();
     }
     const token = this.auth.sign(user.id);
-    res.cookie('token', token, { httpOnly: true });
-    if (user.role === UserRole.Admin) {
-      const basic = Buffer.from(`${email}:${password}`).toString('base64');
-      res.cookie('auth', basic, { httpOnly: true });
-    } else {
-      res.clearCookie('auth');
-    }
+    res.cookie('token', token, this.tokenCookieOptions);
     const { id, email: userEmail, role } = user;
     return { id, email: userEmail, role };
   }
 
   @Post('logout')
   async logout(@Res({ passthrough: true }) res: Response) {
-    res.clearCookie('token');
-    res.clearCookie('auth');
+    res.clearCookie('token', {
+      path: this.tokenCookieOptions.path,
+      sameSite: this.tokenCookieOptions.sameSite,
+      secure: this.tokenCookieOptions.secure,
+      httpOnly: this.tokenCookieOptions.httpOnly,
+    });
     return {};
   }
 


### PR DESCRIPTION
### Motivation
- Удалить небезопасную практику сохранения Basic-credentials в cookie `auth` (`email:password` в base64). 
- Сделать хранение JWT в cookie более безопасным через явные флаги и параметры. 
- Обеспечить корректную очистку cookie при `logout` с теми же атрибутами, чтобы удаление было надежным.

### Description
- Удалил установку и очистку cookie `auth` и связанный код проверки роли в `apps/api/src/auth/auth.controller.ts`.
- Ввёл единый объект опций `tokenCookieOptions` с безопасными атрибутами: `httpOnly: true`, `secure: process.env.NODE_ENV === 'production'`, `sameSite: 'lax'`, `maxAge: 60 * 60 * 1000`, `path: '/'`.
- Использую `res.cookie('token', token, this.tokenCookieOptions)` при логине вместо прежней простой установки `httpOnly`.
- Обновил `logout`, чтобы вызывать `res.clearCookie('token', { path, sameSite, secure, httpOnly })` с теми же значениями, что и при установке.

### Testing
- Выполнена сборка проекта с помощью `npm --prefix apps/api run build` и сборка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e8ebc1608324bd970b0a16bb8a48)