### PR TITLE
Require JWT_SECRET and validate API env config at startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DATABASE_URL="postgresql://user:pass@localhost:5432/afterlight?schema=public"
+JWT_SECRET="replace-with-64-char-random-hex-key-like-4f8b2d6a9c1e3f7b0d2a4c6e8f1a3b5d7c9e0a2b4d6f8a1c3e5b7d9f0a2c4e6"
 NODE_ENV="development"
 PORT=3000
 DEFAULT_DEBUG_USER=""

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -8,12 +8,21 @@ import { NotificationsService } from '../notifications/notifications.service';
 
 @Injectable()
 export class AuthService {
-  private readonly secret = process.env.JWT_SECRET || 'secret';
+  private readonly secret = this.getJwtSecret();
 
   constructor(
     private readonly prisma: PrismaService,
     private readonly notifications: NotificationsService,
   ) {}
+
+  private getJwtSecret(): string {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new Error('JWT_SECRET is required');
+    }
+
+    return secret;
+  }
 
   private hashToken(token: string): string {
     return createHash('sha256').update(token).digest('hex');

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -8,7 +8,30 @@ import { RolesGuard } from './auth/guards/roles.guard';
 import helmet from 'helmet';
 import { json } from 'express';
 
+type RequiredEnvVar = 'JWT_SECRET' | 'DATABASE_URL' | 'CORS_ALLOWED_ORIGINS';
+
+function validateEnv(): void {
+  const requiredEnvVars: RequiredEnvVar[] = [
+    'JWT_SECRET',
+    'DATABASE_URL',
+    'CORS_ALLOWED_ORIGINS',
+  ];
+
+  const missingEnvVars = requiredEnvVars.filter((envVar) => {
+    const value = process.env[envVar];
+    return !value || !value.trim();
+  });
+
+  if (missingEnvVars.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missingEnvVars.join(', ')}`,
+    );
+  }
+}
+
 async function bootstrap() {
+  validateEnv();
+
   const app = await NestFactory.create(AppModule);
   app.enableShutdownHooks();
 


### PR DESCRIPTION
### Motivation
- Убрать опасный fallback для JWT секрета и предотвращать запуск API без конфиденциального ключа.
- Централизовать проверку обязательных переменных окружения, чтобы ранний провал старта указывал на неправильную конфигурацию.

### Description
- В `AuthService` удалён fallback `process.env.JWT_SECRET || 'secret'` и добавлен метод `getJwtSecret()` который бросает ошибку если `JWT_SECRET` не задан.
- В `apps/api/src/main.ts` добавлена функция `validateEnv()` которая проверяет наличие `JWT_SECRET`, `DATABASE_URL` и `CORS_ALLOWED_ORIGINS` и вызывает её перед bootstrap приложения.
- Обновлён `.env.example`, добавлен пример длинного случайного `JWT_SECRET` чтобы явно требовать сильный ключ.

### Testing
- Выполнена сборка проекта API с командой `npm --prefix apps/api run build`, сборка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e9f705c0832496576c3584ccfee0)