### PR TITLE
docs: modernize README and add production Docker Compose server deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,17 @@
-DATABASE_URL="postgresql://user:pass@localhost:5432/afterlight?schema=public"
+# API
+DATABASE_URL="postgresql://afterlight:afterlight@db:5432/afterlight?schema=public"
 JWT_SECRET="replace-with-64-char-random-hex-key-like-4f8b2d6a9c1e3f7b0d2a4c6e8f1a3b5d7c9e0a2b4d6f8a1c3e5b7d9f0a2c4e6"
-NODE_ENV="development"
+NODE_ENV="production"
 PORT=3000
 DEFAULT_DEBUG_USER=""
 CORS_ALLOWED_ORIGINS="http://localhost:3001"
 JSON_BODY_LIMIT="100kb"
+
+# WEB
+NEXT_PUBLIC_API_URL="http://localhost:3000"
+WEB_PORT=80
+
+# POSTGRES (for docker-compose.server.yml)
+POSTGRES_DB="afterlight"
+POSTGRES_USER="afterlight"
+POSTGRES_PASSWORD="change-me-strong-password"

--- a/README.md
+++ b/README.md
@@ -1,114 +1,69 @@
 <div align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&height=220&color=0:0F172A,50:111827,100:1D4ED8&text=Afterlight&fontColor=E2E8F0&fontSize=64&desc=Digital%20legacy%20platform%20(MVP)&descAlignY=65&animation=fadeIn" alt="Afterlight banner" />
 
-  <p>
-    <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-22C55E"></a>
-    <img alt="Monorepo" src="https://img.shields.io/badge/monorepo-apps%2Fapi%20%2B%20apps%2Fweb-6366F1">
-    <img alt="NestJS" src="https://img.shields.io/badge/API-NestJS%2010-EA2845">
-    <img alt="Next.js" src="https://img.shields.io/badge/Web-Next.js%2014-000000">
-    <img alt="Prisma" src="https://img.shields.io/badge/ORM-Prisma%205-2D3748">
-  </p>
+# 🌌 Afterlight
+### Digital legacy platform (MVP)
 
-  <p><b>Afterlight</b> — сервис цифрового наследия: безопасная подготовка и передача данных по заранее заданным условиям.</p>
+<p>
+  <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-22C55E"></a>
+  <img alt="API" src="https://img.shields.io/badge/API-NestJS%2010-EA2845">
+  <img alt="Web" src="https://img.shields.io/badge/Web-Next.js%2014-000000">
+  <img alt="ORM" src="https://img.shields.io/badge/ORM-Prisma%205-2D3748">
+  <img alt="Deploy" src="https://img.shields.io/badge/Deploy-Docker%20Compose-2496ED">
+</p>
+
+**Afterlight** — сервис цифрового наследия: безопасное хранение, управление доступом и сценарии раскрытия данных по событиям.
+
 </div>
 
 ---
 
-## ✨ Что это
-Afterlight — monorepo из двух приложений:
+## ✨ Возможности
 
-- **`apps/api`**: NestJS API с PostgreSQL/Prisma, JWT-аутентификацией, ролями и Swagger.
-- **`apps/web`**: Next.js интерфейс (landing + кабинет + страницы политики/контактов).
-
-Продуктовая идея: владелец хранит данные в сейфе, назначает получателей/верификаторов, а раскрытие запускается через событие и подтверждения.
-
----
-
-## 🧱 Текущие возможности (по коду)
-
-### Backend (API)
-- JWT auth: `register`, `login`, `logout`, `me`.
-- Сейфы и настройки сейфа.
-- Блоки данных, привязка получателей к блокам.
-- Публичные ссылки для блоков (`/blocks/{id}/public`).
-- Верификаторы и события верификации.
-- Heartbeat-конфигурация и ping.
-- Оркестрация событий (`/orchestration/start`, `/orchestration/decision`).
-- CRUD для пользователей, планов, подписок, аудит-логов, recovery shares.
-- Health/readiness endpoints: `/healthz`, `/readyz`.
-- Swagger: `/docs`.
-
-### Frontend (Web)
-- Маршруты: `/`, `/register`, `/cabinet`, `/policies`, `/contacts`.
-- Клиент API через `NEXT_PUBLIC_API_URL`.
-- Отдельный server route для защищённой настройки landing: `GET/HEAD /api/landing` (Basic auth, проверка admin в БД).
-- Анимированный landing (Framer Motion, particles background).
+- 🔐 JWT-аутентификация: `register`, `login`, `logout`, `me`.
+- 🗂️ Сейфы, блоки данных, получатели, публичные ссылки.
+- ✅ Верификаторы, события верификации, оркестрация решений.
+- 🩺 Health/readiness endpoints: `/healthz`, `/readyz`.
+- 📘 Swagger документация: `/docs`.
+- 🖥️ Web-интерфейс: landing, регистрация, кабинет, policies, contacts.
 
 ---
 
-## 🗺️ Архитектура
+## 🧱 Стек
 
-```mermaid
-flowchart LR
-  U[User Browser] --> W[Next.js Web\napps/web]
-  W -->|REST / JWT| A[NestJS API\napps/api]
-  A --> P[(PostgreSQL)]
-  A --> S[Swagger /docs]
-```
-
-### Основные доменные сущности
-
-```mermaid
-erDiagram
-  USER ||--o{ VAULT : owns
-  VAULT ||--o{ BLOCK : contains
-  VAULT ||--o{ VERIFICATION_EVENT : has
-  VAULT ||--o{ VERIFIER : includes
-  BLOCK ||--o{ PUBLIC_LINK : exposes
-  BLOCK ||--o{ RECIPIENT_ASSIGNMENT : assigned_to
-  RECIPIENT ||--o{ RECIPIENT_ASSIGNMENT : receives
-```
+- **Backend**: NestJS + Prisma + PostgreSQL
+- **Frontend**: Next.js 14 (SSR)
+- **Infra**: Docker / Docker Compose, Kubernetes manifests (`k8s/`)
 
 ---
 
-## 🚀 Быстрый старт (локально)
+## 🚀 Быстрый старт (локальная разработка)
 
 ### 1) Требования
+
 - Node.js 20+
 - npm 10+
 - PostgreSQL 15+
 
-### 2) Установка
+### 2) Установка зависимостей
+
 ```bash
-# API
-cd apps/api
-npm ci
-
-# WEB
-cd ../web
-npm ci
+cd apps/api && npm ci
+cd ../web && npm ci
 ```
 
-### 3) ENV
-Создайте `.env` (или экспортируйте переменные) для API на базе `.env.example`:
+### 3) Настройка переменных
 
-```env
-DATABASE_URL="postgresql://user:pass@localhost:5432/afterlight?schema=public"
-JWT_SECRET="replace-with-64-char-random-hex-key"
-NODE_ENV="development"
-PORT=3000
-DEFAULT_DEBUG_USER=""
-CORS_ALLOWED_ORIGINS="http://localhost:3001"
-JSON_BODY_LIMIT="100kb"
+```bash
+cp .env.example .env
 ```
 
-Для Web:
+Минимально проверьте:
+- `DATABASE_URL`
+- `JWT_SECRET`
+- `NEXT_PUBLIC_API_URL`
 
-```env
-NEXT_PUBLIC_API_URL="http://localhost:3000"
-```
+### 4) Подготовка БД
 
-### 4) База данных
 ```bash
 cd apps/api
 npx prisma generate
@@ -118,61 +73,55 @@ npx prisma db seed
 ```
 
 ### 5) Запуск
-```bash
-# terminal 1
-cd apps/api
-npm run start:dev
-
-# terminal 2
-cd apps/web
-npm run dev
-```
-
-- Web: `http://localhost:3000` (или порт из команды)
-- API Swagger: `http://localhost:3000/docs`
-
----
-
-## 🧪 Полезные команды
 
 ```bash
-# API tests
-cd apps/api && npm test
+# API
+cd apps/api && npm run start:dev
 
-# WEB tests
-cd apps/web && npm test
-
-# Сгенерировать openapi.json (API)
-cd apps/api && npm run openapi
-
-# Обновить типы API в WEB
-cd apps/web && npm run openapi
+# WEB (в отдельном терминале)
+cd apps/web && npm run dev
 ```
 
 ---
 
-## ☸️ Деплой
-- Kubernetes-манифесты: `k8s/base/*`
-- Отдельные инструкции:
-  - `docs/deploy.md`
-  - `docs/INSTALL.md`
-  - `k8s/README.md`
+## 🖥️ Deploy на сервер (рекомендуемый путь)
+
+Для VPS/dedicated сервера добавлен готовый сценарий через Docker Compose:
+
+- `docker-compose.server.yml` — production stack (db + api + web + migrate job)
+- `docs/deploy.md` — пошаговая инструкция деплоя и обновления
+
+Быстрый запуск:
+
+```bash
+cp .env.example .env
+# отредактируйте секреты в .env
+
+docker compose -f docker-compose.server.yml up -d --build db api web
+docker compose -f docker-compose.server.yml run --rm migrate
+```
 
 ---
 
 ## 📚 Документация
-- `docs/web.md` — актуальная структура web и маршруты.
-- `docs/ops/EnvVars.md` — обязательные и опциональные переменные окружения.
-- `docs/api/openapi.yaml` и `apps/api/openapi.json` — API контракт.
+
+- `docs/deploy.md` — деплой на сервер (Docker Compose).
+- `docs/INSTALL.md` — установка и запуск.
+- `docs/web.md` — структура web-части.
+- `docs/ops/EnvVars.md` — переменные окружения.
+- `k8s/README.md` — Kubernetes сценарий.
 
 ---
 
 ## 🛡️ Безопасность
-- Не коммитьте секреты в git.
-- Минимум для production: сильный `JWT_SECRET`, закрытый доступ к БД, корректный `CORS_ALLOWED_ORIGINS`, TLS на ingress.
-- Для seed admin-пользователя можно переопределить пароль через `ADMIN_PASSWORD` перед `prisma db seed`.
+
+- Никогда не коммитьте `.env` и секреты.
+- Для production используйте длинный `JWT_SECRET`.
+- Ограничьте доступ к PostgreSQL из внешней сети.
+- Обязательно включите TLS на домене (Caddy/Nginx/Traefik/Cloudflare).
 
 ---
 
 ## 📄 License
+
 MIT — см. [LICENSE](./LICENSE).

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -1,0 +1,74 @@
+name: afterlight
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: afterlight-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-afterlight}
+      POSTGRES_USER: ${POSTGRES_USER:-afterlight}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-afterlight}
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-afterlight} -d ${POSTGRES_DB:-afterlight}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    container_name: afterlight-api
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://afterlight:afterlight@db:5432/afterlight?schema=public}
+      NODE_ENV: ${NODE_ENV:-production}
+      PORT: 3000
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://afterlight:afterlight@db:5432/afterlight?schema=public}
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ["npx", "prisma", "migrate", "deploy"]
+    restart: "no"
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+    container_name: afterlight-web
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: production
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://api:3000}
+      PORT: 3000
+    depends_on:
+      api:
+        condition: service_healthy
+    ports:
+      - "${WEB_PORT:-80}:3000"
+
+volumes:
+  pg_data:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,76 +1,135 @@
-# AfterLight — Deploy (API + WEB) на k3s (VDS) с GHCR
+# 🚀 Afterlight — Production Deploy Guide (VPS / Dedicated Server)
 
-Цель: собрать Docker‑образы из CI, запушить в GHCR, задеплоить в k3s (Traefik). Namespace: **afterlight**.
+> Актуально для **Ubuntu 22.04/24.04** и Docker Compose.
+> Цель: запустить Afterlight (API + Web + Postgres) на вашем сервере с автоперезапуском и healthcheck.
 
-## 0. Предпосылки
-- DNS: `api.afterl.ru`, `app.afterl.ru` указывают на VDS.
-- k3s установлен (Traefik ingress по умолчанию).
-- Внешний PostgreSQL доступен.
-- Репозиторий публичный; GHCR доступен по GITHUB_TOKEN.
+---
 
-## 1. CI → GHCR
-Workflows:
-- `.github/workflows/docker-api.yml` → `ghcr.io/<owner>/afterlight-api:latest`
-- `.github/workflows/docker-web.yml` → `ghcr.io/<owner>/afterlight-web:latest`
+## 1) Что будет развернуто
 
-Для WEB требуется Next `output: 'standalone'` в `apps/web/next.config.mjs`.
+- `afterlight-db` — PostgreSQL 16
+- `afterlight-api` — NestJS API (`:3000` внутри сети)
+- `afterlight-web` — Next.js SSR (`:3000` внутри сети, проброшен наружу)
+- `afterlight-migrate` — одноразовый job для миграций Prisma
 
-## 2. Namespace и секреты
+Схема трафика:
+
+```text
+Internet -> Server:80 -> afterlight-web -> afterlight-api -> afterlight-db
+```
+
+---
+
+## 2) Подготовка сервера
+
 ```bash
-kubectl create namespace afterlight || true
-kubectl -n afterlight create secret generic api-secrets \
-  --from-literal=DATABASE_URL='postgresql://user:pass@db-host:5432/afterlight?schema=public' \
-  --from-literal=JWT_SECRET='please-change-me' \
-  --dry-run=client -o yaml | kubectl apply -f -
+sudo apt update
+sudo apt install -y ca-certificates curl gnupg
+
+# Docker Engine + Compose plugin
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+newgrp docker
+
+docker --version
+docker compose version
 ```
 
-## 3. API
+---
+
+## 3) Развёртывание проекта
+
 ```bash
-kubectl apply -n afterlight -f https://raw.githubusercontent.com/grayhex/afterlight/main/k8s/base/api-configmap.yaml
-kubectl apply -n afterlight -f https://raw.githubusercontent.com/grayhex/afterlight/main/k8s/base/api-deployment.yaml
-kubectl apply -n afterlight -f https://raw.githubusercontent.com/grayhex/afterlight/main/k8s/base/api-service.yaml
-kubectl apply -n afterlight -f https://raw.githubusercontent.com/grayhex/afterlight/main/k8s/base/api-ingress.yaml
-kubectl apply -n afterlight -f https://raw.githubusercontent.com/grayhex/afterlight/main/k8s/base/migrate-job.yaml
-kubectl -n afterlight logs job/prisma-migrate -f
+git clone <YOUR_REPO_URL> afterlight
+cd afterlight
+cp .env.example .env
 ```
 
-## 4. WEB
+Откройте `.env` и обязательно замените:
+
+- `DATABASE_URL`
+- `JWT_SECRET` (длинный случайный ключ)
+- `CORS_ALLOWED_ORIGINS` (ваш домен)
+- `NEXT_PUBLIC_API_URL` (URL API, видимый фронту)
+
+Рекомендуемый production-пример:
+
+```env
+DATABASE_URL="postgresql://afterlight:CHANGE_ME_STRONG@db:5432/afterlight?schema=public"
+JWT_SECRET="CHANGE_ME_LONG_RANDOM_64_CHARS_MIN"
+NODE_ENV="production"
+PORT=3000
+CORS_ALLOWED_ORIGINS="https://app.example.com"
+JSON_BODY_LIMIT="100kb"
+NEXT_PUBLIC_API_URL="https://api.example.com"
+POSTGRES_DB="afterlight"
+POSTGRES_USER="afterlight"
+POSTGRES_PASSWORD="CHANGE_ME_STRONG"
+WEB_PORT=80
+```
+
+---
+
+## 4) Первый запуск
+
 ```bash
-kubectl apply -n afterlight -f https://raw.githubusercontent.com/grayhex/afterlight/main/k8s/base/web-configmap.yaml
-kubectl apply -n afterlight -f https://raw.githubusercontent.com/grayhex/afterlight/main/k8s/base/web-deployment.yaml
-kubectl apply -n afterlight -f https://raw.githubusercontent.com/grayhex/afterlight/main/k8s/base/web-service.yaml
-kubectl apply -n afterlight -f https://raw.githubusercontent.com/grayhex/afterlight/main/k8s/base/web-ingress.yaml
+# 1) Собрать и поднять базовые сервисы
+docker compose -f docker-compose.server.yml up -d --build db api web
+
+# 2) Прогнать миграции
+# (job завершится с кодом 0)
+docker compose -f docker-compose.server.yml run --rm migrate
+
+# 3) Проверить статус
+docker compose -f docker-compose.server.yml ps
+curl -f http://127.0.0.1:${WEB_PORT:-80}/ || true
+curl -f http://127.0.0.1:${WEB_PORT:-80}/api/healthz || true
 ```
 
-Проверка:
+---
+
+## 5) Обновление приложения
+
 ```bash
-kubectl -n afterlight rollout status deploy/afterlight-web
-kubectl -n afterlight get deploy afterlight-web -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
-kubectl -n afterlight get pods -l app=afterlight-web -o wide
-kubectl -n afterlight logs deploy/afterlight-web --tail=100
+git pull
+docker compose -f docker-compose.server.yml up -d --build api web
+docker compose -f docker-compose.server.yml run --rm migrate
 ```
 
-## 5. CORS (API)
-```ts
-app.enableCors({
-  origin: [/^https?:\/\/(localhost:\d+|app\.afterl\.ru)$/],
-  allowedHeaders: ['Content-Type', 'x-user-id', 'Authorization'],
-  methods: ['GET','POST','PUT','PATCH','DELETE','OPTIONS'],
-});
+---
+
+## 6) Резервное копирование базы
+
+```bash
+mkdir -p backups
+docker exec afterlight-db pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" > backups/afterlight_$(date +%F).sql
 ```
 
-## 6. Smoke‑тест (Playground)
-1) POST /vaults → vaultId  
-2) POST /recipients → recipientId  
-3) POST /blocks (multipart) → blockId  
-4) POST /blocks/{id}/recipients  
-5) POST /orchestration/start  
-6) POST /orchestration/decision (Confirm) до кворума  
-7) (опц.) PUT /blocks/{id}/public
+---
 
-## 7. Обновление/роллбэк
-- Обновить: push в main → новый `:latest` → `kubectl -n afterlight rollout restart deploy/afterlight-web`
-- Роллбэк: `kubectl -n afterlight rollout undo deploy/afterlight-web`
+## 7) HTTPS (рекомендовано)
 
-## 8. Как запускать сид
-Сид запускается вручную через workflow `seed` с подтверждением `prod`.
+Варианты:
+- Caddy / Nginx Proxy Manager / Traefik на сервере.
+- Cloudflare Tunnel.
+
+Минимум для production:
+- включить TLS;
+- ограничить доступ к `:5432` снаружи;
+- хранить `.env` только на сервере;
+- регулярно обновлять образы и ОС.
+
+---
+
+## 8) Быстрая диагностика
+
+```bash
+docker compose -f docker-compose.server.yml logs --tail=100 web
+docker compose -f docker-compose.server.yml logs --tail=100 api
+docker compose -f docker-compose.server.yml logs --tail=100 db
+```
+
+Health endpoints API:
+- `/healthz`
+- `/readyz`
+- `/docs`


### PR DESCRIPTION
### Motivation
- Подготовить простой и надёжный путь деплоя на личный VPS / dedicated server (Docker Compose), дополнительно к существующим k8s-инструкциям. 
- Сделать `README` более современным и понятным для новых разработчиков и админов. 
- Предоставить готовый production-oriented стек для быстрого запуска (DB + API + Web + migrate). 

### Description
- Обновлён `README.md` с современной структурой, кратким quick-start и явным разделом про деплой на сервер, ссылками на новые инструкции и рекомендации по безопасности. 
- Заменён/переписан `docs/deploy.md` на пошаговое руководство для VPS/Docker Compose (подготовка сервера, первый запуск, миграции, обновления, бэкапы, TLS, диагностика). 
- Добавлен `docker-compose.server.yml` с сервисами `db`, `api`, `web` и одноразовым `migrate` job, включающим healthcheck'и и настройки перезапуска. 
- Обновлён `.env.example` с production-ориентированными значениями и новыми переменными: `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `NEXT_PUBLIC_API_URL`, `WEB_PORT` и т.д. 

### Testing
- Попытка валидации конфигурации Compose через `docker compose -f docker-compose.server.yml config` не завершилась, так как в окружении отсутствует Docker CLI (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4de5d37a883248e9bbc6fa44d632a)